### PR TITLE
add slots feature

### DIFF
--- a/.changeset/little-birds-kiss.md
+++ b/.changeset/little-birds-kiss.md
@@ -1,0 +1,30 @@
+---
+"@layerfig/config": minor
+---
+
+Add `slots` feature.
+
+Now you can use slots to use environment variable values values:
+
+`.env` or similar:
+
+```env
+PORT=3000
+```
+
+Your config file:
+```json
+{
+  "port": "$PORT"
+}
+```
+
+In your validate function, you'll receive:
+
+```json
+{
+  "port": "3000"
+}
+```
+
+> [Read more about slots](https://layerfig.raulmelo.workers.dev/introduction/setup/slots/)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -36,7 +36,7 @@ export default defineConfig({
 				},
 				{
 					label: "Setup",
-					items: ["setup/configuration", "setup/sources"],
+					items: ["setup/configuration", "setup/sources", "setup/slots"],
 				},
 				{
 					label: "Parsers",

--- a/docs/src/content/docs/setup/configuration.mdx
+++ b/docs/src/content/docs/setup/configuration.mdx
@@ -64,3 +64,44 @@ const config = new ConfigBuilder({
 ```
 
 In this case, the library will look for `<root>/path/to/config-folder/base.json` and load it.
+
+## options.slotPrefix
+
+> Default: "$"
+
+A string used to identify slots that should be replaced with environment variables.
+
+By default, Layerfig looks for placeholders prefixed with `$`. You can customize this prefix if it conflicts with other syntax or to match a team's convention.
+
+<Aside>
+    Read more about [slots](/setup/slots).
+</Aside>
+
+
+For example, to use a double underscore (`__`) as the prefix:
+
+```ts
+const config = new ConfigBuilder({
+  validate: (finalConfig) => schema.parse(finalConfig),
+  slotPrefix: '__'
+})
+  .addSource("base.json")
+  .build();
+```
+
+Layerfig will now look for slots like `__PORT` in your configuration files.
+
+```json
+// config/base.json
+{
+  "appURL": "http://localhost:__PORT",
+  "port": "__PORT"
+}
+```
+
+With the `PORT` environment variable set, the resolved configuration would be:
+
+```js
+config.appURL; // http://localhost:3000
+config.port; // 3000
+```

--- a/docs/src/content/docs/setup/slots.mdx
+++ b/docs/src/content/docs/setup/slots.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Slots'
+---
+
+There are cases where we want to have our config file but derive values from environment variables.
+
+Imagine the following config file:
+
+```json
+// config/base.json
+{
+  "appURL": "http://localhost:3000",
+  "port": 3000
+}
+```
+
+As you can see, `port` is the same in both places. Now, imagine we have `PORT` declared in our `.env` file on exported in the environment we are. We want to use this value and compose, right?
+
+```env
+PORT=3000
+```
+
+To use this value, you can use slots:
+
+```json
+// config/base.json
+{
+  "appURL": "http://localhost:$PORT",
+  "port": "$PORT"
+}
+```
+
+When layerfig reads your file, it'll search for slots and attempts to replace with an environment variable value with the same name:
+
+```
+$PORT => PORT => 3000
+```
+
+## Caveats
+
+Important to mention that if the value is not declared in the environment variable, layerfig will not replace with anything. That means your config variable will contain the value with the slot:
+
+```ts
+config.appURL; // http://localhost:$PORT
+```
+
+Also, keep in mind that all environment variables are typeof string. For example, let's say you want `port` to be typeof number. Using slots, your validate function will receive the following object:
+
+```js
+const finalConfig = {
+  appURL: "http://localhost:3000",
+  port: "3000"
+}
+```
+
+So, in your schema, you might want to do something like this:
+
+```ts {5}
+import { z } from 'zod/v4'
+
+const schema = z.object({
+	appURL: z.string(),
+	port: z.coerce.number().positive().int(),
+});
+```
+
+By doing this, you'll get `"3000"` (string) and the schema will automatically coerce to `3000` (number).

--- a/docs/src/content/docs/setup/slots.mdx
+++ b/docs/src/content/docs/setup/slots.mdx
@@ -2,9 +2,9 @@
 title: 'Slots'
 ---
 
-There are cases where we want to have our config file but derive values from environment variables.
+You may need to define your configuration in a file while also sourcing values from environment variables.
 
-Imagine the following config file:
+Consider the following configuration file:
 
 ```json
 // config/base.json
@@ -14,13 +14,13 @@ Imagine the following config file:
 }
 ```
 
-As you can see, `port` is the same in both places. Now, imagine we have `PORT` declared in our `.env` file on exported in the environment we are. We want to use this value and compose, right?
+Notice that the port number is used in two places. Instead of hardcoding this value, you can use a `PORT` variable defined in your environment, such as in a `.env` file:
 
 ```env
 PORT=3000
 ```
 
-To use this value, you can use slots:
+To reference this environment variable, you can use a "slot":
 
 ```json
 // config/base.json
@@ -30,7 +30,7 @@ To use this value, you can use slots:
 }
 ```
 
-When layerfig reads your file, it'll search for slots and attempts to replace with an environment variable value with the same name:
+When Layerfig processes your configuration, it searches for slots and replaces them with the corresponding environment variable's value:
 
 ```
 $PORT => PORT => 3000
@@ -38,13 +38,13 @@ $PORT => PORT => 3000
 
 ## Caveats
 
-Important to mention that if the value is not declared in the environment variable, layerfig will not replace with anything. That means your config variable will contain the value with the slot:
+If an environment variable for a slot is not defined, Layerfig will not perform a replacement. The configuration value will retain the original slot string:
 
 ```ts
-config.appURL; // http://localhost:$PORT
+config.appURL; // "http://localhost:$PORT"
 ```
 
-Also, keep in mind that all environment variables are typeof string. For example, let's say you want `port` to be typeof number. Using slots, your validate function will receive the following object:
+Additionally, all environment variables are treated as strings. If a slot is used for a value that should be a number, like `port`, the resulting configuration will have a string value:
 
 ```js
 const finalConfig = {
@@ -53,7 +53,7 @@ const finalConfig = {
 }
 ```
 
-So, in your schema, you might want to do something like this:
+To handle this, you can use a validation schema to coerce the string value into a number. For example, with Zod:
 
 ```ts {5}
 import { z } from 'zod/v4'
@@ -64,4 +64,4 @@ const schema = z.object({
 });
 ```
 
-By doing this, you'll get `"3000"` (string) and the schema will automatically coerce to `3000` (number).
+The `z.coerce.number()` function will parse the string `"3000"` and transform it into the number `3000`.

--- a/docs/src/content/docs/setup/slots.mdx
+++ b/docs/src/content/docs/setup/slots.mdx
@@ -65,3 +65,7 @@ const schema = z.object({
 ```
 
 The `z.coerce.number()` function will parse the string `"3000"` and transform it into the number `3000`.
+
+## Different Prefix
+
+By default Layerfig uses `$` as slot prefix, but you can change it by passing [`slotPrefix`](/setup/configuration/#optionsslotprefix) in the options.

--- a/packages/config/src/__fixtures__/schema.ts
+++ b/packages/config/src/__fixtures__/schema.ts
@@ -1,7 +1,0 @@
-import { z } from "zod";
-
-export default z.object({
-	name: z.string(),
-	version: z.number(),
-	description: z.string(),
-});

--- a/packages/config/src/__fixtures__/slot-multiple.json
+++ b/packages/config/src/__fixtures__/slot-multiple.json
@@ -1,0 +1,5 @@
+{
+	"appURL": "http://localhost:$PORT",
+	"port": "$PORT",
+	"host": "$HOST"
+}

--- a/packages/config/src/__fixtures__/slot-prefix.json
+++ b/packages/config/src/__fixtures__/slot-prefix.json
@@ -1,0 +1,4 @@
+{
+	"appURL": "http://localhost:@PORT",
+	"port": "@PORT"
+}

--- a/packages/config/src/__fixtures__/slot.json
+++ b/packages/config/src/__fixtures__/slot.json
@@ -1,0 +1,4 @@
+{
+	"appURL": "http://localhost:$PORT",
+	"port": "$PORT"
+}

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -198,6 +198,23 @@ describe("ConfigBuilder", () => {
 
 			process.env.PORT = undefined;
 		});
+
+		it("should accept custom slot prefix", () => {
+			const config = new ConfigBuilder({
+				validate: (config) => schema.parse(config),
+				configFolder: "./src/__fixtures__",
+				slotPrefix: "@",
+			});
+
+			process.env.PORT = "3000";
+
+			expect(config.addSource("slot-prefix.json").build()).toEqual({
+				appURL: "http://localhost:3000",
+				port: 3000,
+			});
+
+			process.env.PORT = undefined;
+		});
 	});
 
 	it("should deep merge configuration", () => {

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -143,6 +143,63 @@ describe("ConfigBuilder", () => {
 		});
 	});
 
+	describe("slots", () => {
+		const schema = z4.object({
+			appURL: z4.string(),
+			port: z4.coerce.number().positive().int(),
+		});
+
+		const config = new ConfigBuilder({
+			validate: (config) => schema.parse(config),
+			configFolder: "./src/__fixtures__",
+		});
+
+		it("should replace the slotted value with the value from env var", () => {
+			process.env.PORT = "3000";
+
+			expect(config.addSource("slot.json").build()).toEqual({
+				appURL: "http://localhost:3000",
+				port: 3000,
+			});
+
+			process.env.PORT = undefined;
+		});
+
+		it("should NOT replace the slotted value if env var is not defined", () => {
+			const config = new ConfigBuilder({
+				validate: (config) => config,
+				configFolder: "./src/__fixtures__",
+			});
+
+			expect(config.addSource("slot.json").build()).toEqual({
+				appURL: "http://localhost:$PORT",
+				port: "$PORT",
+			});
+		});
+
+		it("should handle multiple slots", () => {
+			process.env.PORT = "3000";
+
+			const schema = z4.object({
+				appURL: z4.string(),
+				port: z4.coerce.number().positive().int(),
+				host: z4.string(),
+			});
+			const config = new ConfigBuilder({
+				validate: (config) => schema.parse(config),
+				configFolder: "./src/__fixtures__",
+			});
+
+			expect(config.addSource("slot-multiple.json").build()).toEqual({
+				appURL: "http://localhost:3000",
+				port: 3000,
+				host: "$HOST",
+			});
+
+			process.env.PORT = undefined;
+		});
+	});
+
 	it("should deep merge configuration", () => {
 		const schema = z3.object({
 			foo: z3.object({

--- a/packages/config/src/config-builder.ts
+++ b/packages/config/src/config-builder.ts
@@ -24,6 +24,11 @@ interface ConfigBuilderOptions<T extends object = Record<string, unknown>> {
 	 * Load source from different source types
 	 */
 	parser?: ConfigParser;
+	/**
+	 * Prefix used to search for slotted values
+	 * @default "$"
+	 */
+	slotPrefix?: string;
 }
 
 export class ConfigBuilder<T extends object = Record<string, unknown>> {
@@ -72,7 +77,6 @@ export class ConfigBuilder<T extends object = Record<string, unknown>> {
 			}
 
 			const finalContent = this.#replaceSlots(fileContentResult.data);
-
 			const parserResult = this.#parser.load(finalContent);
 
 			if (parserResult.ok) {
@@ -88,7 +92,8 @@ export class ConfigBuilder<T extends object = Record<string, unknown>> {
 	}
 
 	#replaceSlots(fileContent: string) {
-		const regex = /\$\w+/g;
+		const slotPrefix = this.#options.slotPrefix || "$";
+		const regex = new RegExp(`\\${slotPrefix}\\w+`, "g");
 
 		const matches = fileContent.match(regex);
 
@@ -101,7 +106,7 @@ export class ConfigBuilder<T extends object = Record<string, unknown>> {
 		let copy = fileContent;
 
 		for (const slot of uniqueSlots) {
-			const slotWithoutPrefix = slot.replace("$", "");
+			const slotWithoutPrefix = slot.replace(slotPrefix, "");
 			const value = process.env[slotWithoutPrefix];
 
 			// Do not replace if the variable is not there

--- a/packages/parser-yaml/src/__fixtures__/base.yaml
+++ b/packages/parser-yaml/src/__fixtures__/base.yaml
@@ -1,2 +1,3 @@
-appURL: http://localhost:$PORT
-port: $PORT
+appURL: https://my-site.com
+api:
+  port: 3000

--- a/packages/parser-yaml/src/__fixtures__/base.yaml
+++ b/packages/parser-yaml/src/__fixtures__/base.yaml
@@ -1,3 +1,2 @@
-appURL: "https://my-site.com"
-api:
-  port: 3000
+appURL: http://localhost:$PORT
+port: $PORT

--- a/packages/parser-yaml/src/__fixtures__/base.yml
+++ b/packages/parser-yaml/src/__fixtures__/base.yml
@@ -1,6 +1,3 @@
-{
-	"appURL": "https://my-site.com",
-	"api": {
-		"port": 3000
-	}
-}
+appURL: https://my-site.com
+api:
+  port: 3000

--- a/packages/parser-yaml/src/__fixtures__/dev.yaml
+++ b/packages/parser-yaml/src/__fixtures__/dev.yaml
@@ -1,3 +1,1 @@
-{
-	"appURL": "https://dev.company-app.com"
-}
+appURL: https://dev.company-app.com


### PR DESCRIPTION
Closes #56 

## Description

This pull request introduces a new "slots" feature to the `@layerfig/config` package, enabling the dynamic replacement of configuration placeholders with environment variable values. It also includes updates to documentation, test cases, and code to support this feature. Below is a summary of the most important changes:

### New Feature: Slots for Environment Variable Replacement
* Added `slots` functionality to allow placeholders in configuration files (e.g., `$PORT`) to be replaced with corresponding environment variable values during runtime. Includes support for custom slot prefixes via the `slotPrefix` option. (`.changeset/little-birds-kiss.md`, `packages/config/src/config-builder.ts`, [[1]](diffhunk://#diff-063ad9227a0ded3855bc1ba840225625eb3563d8cd2e85a254a44d5899405db8R1-R30) [[2]](diffhunk://#diff-fe57f2f603720d0643cf99a15e4355fe4611277dd44a0533a32afa69508859f3R27-R31) [[3]](diffhunk://#diff-fe57f2f603720d0643cf99a15e4355fe4611277dd44a0533a32afa69508859f3L74-R80) [[4]](diffhunk://#diff-fe57f2f603720d0643cf99a15e4355fe4611277dd44a0533a32afa69508859f3R94-R120)

### Documentation Updates
* Updated `astro.config.mjs` to include a new "Slots" section in the documentation navigation.
* Added detailed documentation for the `slots` feature, including usage examples, caveats, and configuration options. (`docs/src/content/docs/setup/configuration.mdx`, `docs/src/content/docs/setup/slots.mdx`, [[1]](diffhunk://#diff-8a85d9f41e5e5fa8ddeea9463f70a9fb0ce8d0f6923fb4e6c715d1e62ed0b98cR67-R107) [[2]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cR1-R71)

### Test Coverage
* Added unit tests to verify the functionality of the `slots` feature, including scenarios for missing environment variables, multiple slots, and custom prefixes. (`packages/config/src/config-builder.test.ts`, [packages/config/src/config-builder.test.tsR146-R219](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5R146-R219))

### Fixtures for Testing
* Introduced new fixture files to test various slot configurations, such as `slot.json`, `slot-multiple.json`, and `slot-prefix.json`. (`packages/config/src/__fixtures__/slot.json`, `packages/config/src/__fixtures__/slot-multiple.json`, `packages/config/src/__fixtures__/slot-prefix.json`, [[1]](diffhunk://#diff-9181864c78834415ec97daca79ffaf09bd5b14ff33ad8d6b1fa7d798f9a803f4R1-R4) [[2]](diffhunk://#diff-fc83104b3fe73cf116ef4c7ac37233d639df79a58920057460b744686eb3a30eR1-R5) [[3]](diffhunk://#diff-31b8fc60dee224889e5620765454e65a3739e8587e7ab0fc472d34cc578787bdR1-R4)

### Cleanup
* Removed an unused schema file from the `__fixtures__` directory. (`packages/config/src/__fixtures__/schema.ts`, [packages/config/src/__fixtures__/schema.tsL1-L7](diffhunk://#diff-3c29fa88ed892eeabaad7df2ff5bcd41a4f167258b84c2fa239f1967be902835L1-L7))