### PR TITLE
[Feature] Add `ObjectSource` for client configuration

### DIFF
--- a/.changeset/cold-pianos-wink.md
+++ b/.changeset/cold-pianos-wink.md
@@ -1,0 +1,5 @@
+---
+"@layerfig/config": minor
+---
+
+remove support for node 10 imports

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
 						"guides/deno",
 						"guides/docker",
 						"guides/dynamic-environment",
+						"guides/client-config",
 					],
 				},
 				{

--- a/docs/src/content/docs/guides/client-config.mdx
+++ b/docs/src/content/docs/guides/client-config.mdx
@@ -1,0 +1,49 @@
+---
+title: Client Configuration
+---
+
+Layerfig was originally designed to work on the server side. This is because it relies on configuration files that you commit (which use Node.js APIs) or on environment variables accessed via `process.env`.
+
+We don't recommend using Layerfig solely for client-side configuration, as this can be accomplished with only a schema validation library like Zod:
+
+```ts
+// client-config.ts
+import { z } from "zod/v4";
+
+const schema = z.object({
+  appURL: z.url(),
+});
+
+export const config = schema.parse({
+  appURL: import.meta.env.PUBLIC_APP_URL,
+});
+```
+
+However, if you are already using Layerfig and want to leverage your existing setup, you can achieve a similar result by using `ObjectSource` and the `slots` feature.
+
+The advantage of this approach is that you can have separate `server-config.ts`, `client-config.ts`, and `schema.ts` files. The client schema can then be derived from the main schema to include only client-specific properties:
+
+> The following example uses [`.pick`](https://zod.dev/api?id=pick) from Zod.
+
+```ts
+// client-config.ts
+import { ConfigBuilder } from "@layerfig/config";
+import { ObjectSource } from "@layerfig/config/sources/object";
+import { configSchema } from "./schema";
+
+export const config = new ConfigBuilder({
+  validate: (finalConfig) =>
+    configSchema
+      .pick({
+        appURL: true,
+      })
+      .parse(finalConfig),
+  runtimeEnv: import.meta.env,
+})
+  .addSource(
+    new Object({
+      appURL: "$PUBLIC_APP_URL",
+    })
+  )
+  .build();
+```

--- a/docs/src/content/docs/setup/sources.mdx
+++ b/docs/src/content/docs/setup/sources.mdx
@@ -10,7 +10,7 @@ Sources define where the library reads your configuration from, such as files or
 
 For loading source from files, use `new FileSource('[file-name].[ext]')`:
 
-```ts {4}
+```ts {2,8}
 import { ConfigBuilder } from "@layerfig/config";
 import { FileSource } from "@layerfig/config/sources/file";
 import { schema } from "./schema";
@@ -24,9 +24,7 @@ export const config = new ConfigBuilder({
 
 In this case, `base.json` is a file located in the `<root-project-dir>/config` directory (or the one specified via `configFolder`).
 
-<Aside>
-  Without a specified parser, you can only load `.json`.
-</Aside>
+<Aside>Without a specified parser, you can only load `.json`.</Aside>
 
 ### Other File Extensions
 
@@ -38,6 +36,34 @@ To support various project needs and preferences, we provide parsers for other c
 
 ... or [you can create your own parser](/parsers/custom).
 
+## Object
+
+The `ObjectSource` is a simple yet powerful tool for creating client-side configurations with Layerfig. It's ideal when you want to avoid using files or need to override/debug your configuration. It also supports `slots`, allowing you to use environment variables:
+
+```ts {2,7,9-12}
+import { ConfigBuilder } from "@layerfig/config";
+import { ObjectSource } from "@layerfig/config/sources/object";
+import { schema } from "./schema";
+
+export const config = new ConfigBuilder({
+  validate: (finalConfig) => schema.parse(finalConfig),
+  runtimeEnv: import.meta.env,
+})
+  .addSource(
+    new ObjectSource({
+      baseURL: "$PUBLIC_BASE_URL",
+      randomValue: true,
+    })
+  )
+  .build();
+```
+
+Since a framework like Vite adds `PUBLIC_*` environment variables to `import.meta.env` and makes them available on the client, your `config` object will contain all the type-checked values.
+
+<Aside>
+  See more details on [Client Configuration](/guides/client-config/) guide.
+</Aside>
+
 ## Environment Variables
 
 Consider the following scenario:
@@ -46,7 +72,7 @@ Your application's configuration files are committed to version control and used
 
 To avoid this, use `EnvironmentVariableSource` to override configuration values at runtime without modifying the source files:
 
-```ts {8}
+```ts {3,10}
 import { ConfigBuilder } from "@layerfig/config";
 import { FileSource } from "@layerfig/config/sources/file";
 import { EnvironmentVariableSource } from "@layerfig/config/sources/env";
@@ -135,7 +161,7 @@ const schema = z.object({
 });
 
 const config = new ConfigBuilder({
-  validate: finalConfig => schema.parse(finalConfig)
+  validate: (finalConfig) => schema.parse(finalConfig),
 })
   .addSource(new FileSource("base.json"))
   .addSource(new EnvironmentVariableSource())
@@ -156,7 +182,7 @@ import { FileSource } from "@layerfig/config/sources/file";
 import { schema } from "./schema";
 
 const config = new ConfigBuilder({
-  validate: finalConfig => schema.parse(finalConfig)
+  validate: (finalConfig) => schema.parse(finalConfig),
 })
   .addSource(new FileSource("base.json"))
   .addSource(

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -59,6 +59,16 @@
 				"types": "./dist/sources/file/index.d.cts",
 				"default": "./dist/sources/file/index.cjs"
 			}
+		},
+		"./sources/object": {
+			"import": {
+				"types": "./dist/sources/object/index.d.ts",
+				"default": "./dist/sources/object/index.js"
+			},
+			"require": {
+				"types": "./dist/sources/object/index.d.cts",
+				"default": "./dist/sources/object/index.cjs"
+			}
 		}
 	},
 	"scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,9 +24,6 @@
 		"access": "public"
 	},
 	"type": "module",
-	"main": "dist/index.cjs",
-	"module": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"LICENSE"

--- a/packages/config/src/sources/object.test.ts
+++ b/packages/config/src/sources/object.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { basicJsonParser } from "../parser/parser-json";
+import { ObjectSource } from "./object";
+import type { LoadSourceOptions } from "./source";
+
+const baseLoadSourceOptions: LoadSourceOptions = {
+	relativeConfigFolderPath: "./src/__fixtures__",
+	parser: basicJsonParser,
+	runtimeEnv: process.env,
+	slotPrefix: "$",
+};
+
+describe("ObjectSource", () => {
+	it("should return the same object", () => {
+		const testObject = {
+			foo: "bar",
+			nested: {
+				baz: "qux",
+			},
+		};
+
+		const envVarSource = new ObjectSource(testObject);
+
+		expect(envVarSource.loadSource(baseLoadSourceOptions)).toEqual(testObject);
+	});
+
+	describe("slots", () => {
+		it("should replace slot value", () => {
+			const testObject = {
+				port: "$PORT",
+				useTLS: true,
+			};
+
+			const envVarSource = new ObjectSource(testObject);
+
+			expect(
+				envVarSource.loadSource({
+					...baseLoadSourceOptions,
+					runtimeEnv: {
+						PORT: "3000",
+					},
+				}),
+			).toEqual({
+				port: "3000",
+				useTLS: true,
+			});
+		});
+
+		it("should replace values with multiple values", () => {
+			const testObject = {
+				port: "$PORT",
+				appURL: "http://$HOST:$PORT",
+				useTLS: true,
+				host: "$HOST",
+			};
+
+			const envVarSource = new ObjectSource(testObject);
+
+			expect(
+				envVarSource.loadSource({
+					...baseLoadSourceOptions,
+					runtimeEnv: {
+						PORT: "3000",
+						HOST: "localhost",
+					},
+				}),
+			).toEqual({
+				port: "3000",
+				appURL: "http://localhost:3000",
+				useTLS: true,
+				host: "localhost",
+			});
+		});
+	});
+});

--- a/packages/config/src/sources/object.ts
+++ b/packages/config/src/sources/object.ts
@@ -1,0 +1,26 @@
+import { type LoadSourceOptions, Source } from "./source";
+
+type AnyRecord = Record<string, unknown>;
+
+export class ObjectSource extends Source {
+	#object: AnyRecord = {};
+
+	constructor(object: AnyRecord) {
+		super();
+
+		this.#object = object;
+	}
+
+	override loadSource({
+		slotPrefix,
+		runtimeEnv,
+	}: LoadSourceOptions): AnyRecord {
+		const replacedObject = this.maybeReplaceSlotFromValue({
+			value: JSON.stringify(this.#object),
+			slotPrefix,
+			runtimeEnv,
+		});
+
+		return JSON.parse(replacedObject);
+	}
+}

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		index: "./src/index.ts",
 		"sources/env/index": "./src/sources/env-var.ts",
 		"sources/file/index": "./src/sources/file.ts",
+		"sources/object/index": "./src/sources/object.ts",
 	},
 	dts: true,
 	sourcemap: true,


### PR DESCRIPTION
> Closes #91 

This pull request introduces significant updates to the `@layerfig/config` package, including the addition of a new `ObjectSource` feature, updates to documentation, and removal of support for Node.js 10 imports. Below is a summary of the most important changes grouped by theme.

### New Feature: ObjectSource

* Added the `ObjectSource` class in `packages/config/src/sources/object.ts`, which allows configurations to be defined as objects, supports slot replacement using environment variables, and provides flexibility for client-side configurations.
* Added unit tests for `ObjectSource` in `packages/config/src/sources/object.test.ts` to ensure correct behavior, including slot replacement and handling nested values.
* Updated the `package.json` file to include proper exports for the `ObjectSource` module.
* Updated `tsdown.config.ts` to include the new `ObjectSource` in the build configuration.

### Documentation Updates

* Added a new guide on client-side configuration (`docs/src/content/docs/guides/client-config.mdx`) explaining how to use `ObjectSource` and the `slots` feature for client-specific setups.
* Updated the `sources.mdx` documentation to include details about `ObjectSource`, its usage, and its advantages for client-side configurations.
* Minor formatting improvements in `sources.mdx` to enhance readability and consistency. [[1]](diffhunk://#diff-a8cc9c00fd3a6a4b1255df6e0ccfa80b3d378f9efbfc2f44243e5a092ce9c7a4L27-R27) [[2]](diffhunk://#diff-a8cc9c00fd3a6a4b1255df6e0ccfa80b3d378f9efbfc2f44243e5a092ce9c7a4L138-R164) [[3]](diffhunk://#diff-a8cc9c00fd3a6a4b1255df6e0ccfa80b3d378f9efbfc2f44243e5a092ce9c7a4L159-R185)

### Breaking Change: Node.js 10 Imports

* Removed support for Node.js 10 imports in `@layerfig/config` as part of a minor version update.

### Other Changes

* Added a new entry for the client configuration guide in `astro.config.mjs` to integrate it into the documentation navigation structure.
* Removed redundant fields (`main`, `module`, `types`) from the `package.json` file to streamline the configuration.