### PR TITLE
upgrade zod to v4 and upgrade usage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "astro": "5.10.1",
         "sharp": "0.34.2",
         "starlight-theme-nova": "0.9.0",
+        "zod": "3.25.76",
       },
     },
     "packages/config": {
@@ -1643,6 +1644,8 @@
     "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "docs/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       "name": "@layerfig/config",
       "version": "2.2.0",
       "dependencies": {
-        "zod": "^3.25.67",
+        "zod": "^4.0.10",
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
@@ -1568,7 +1568,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.1", "", {}, "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="],
 
-    "zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
+    "zod": ["zod@4.0.10", "", {}, "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
@@ -1583,6 +1583,8 @@
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
     "@aria-ui/tooltip/nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+
+    "@astrojs/sitemap/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
 
     "@astrojs/telemetry/ci-info": ["ci-info@4.3.0", "", {}, "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ=="],
 
@@ -1629,6 +1631,8 @@
     "astro/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "astro/vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
+
+    "astro/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1692,7 +1696,11 @@
 
     "yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
+    "zod-to-json-schema/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
+
     "zod-to-ts/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "zod-to-ts/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
 
     "@changesets/parse/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
 		"@astrojs/starlight": "0.34.4",
 		"astro": "5.10.1",
 		"sharp": "0.34.2",
-		"starlight-theme-nova": "0.9.0"
+		"starlight-theme-nova": "0.9.0",
+		"zod": "3.25.76"
 	}
 }

--- a/docs/src/content/docs/guides/client-config.mdx
+++ b/docs/src/content/docs/guides/client-config.mdx
@@ -8,7 +8,7 @@ We don't recommend using Layerfig solely for client-side configuration, as this 
 
 ```ts
 // client-config.ts
-import { z } from "zod/v4";
+import { z } from "zod";
 
 const schema = z.object({
   appURL: z.url(),

--- a/docs/src/content/docs/setup/sources.mdx
+++ b/docs/src/content/docs/setup/sources.mdx
@@ -121,7 +121,7 @@ export const config = new ConfigBuilder({
   validate: (finalConfig, z) => {
     const schema = z.object({
       appURL: z.url(),
-      port: z.coerce.number().int().positive(),
+      port: z.coerce.number().check(z.int(), z.positive()),
       appEnv: z.enum(["local", "dev", "prod"]),
     });
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -60,7 +60,7 @@
 		"test:coverage": "bun run test --coverage --coverage.exclude src/__fixtures__ --coverage.include src"
 	},
 	"dependencies": {
-		"zod": "^3.25.67"
+		"zod": "^4.0.10"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "0.18.2",

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -248,14 +248,14 @@ describe("ConfigBuilder", () => {
 					.addSource(new ObjectSource({ appURL: "not-a-url" }))
 					.build(),
 			).toThrowErrorMatchingInlineSnapshot(`
-				[ZodError: [
+				[$ZodError: [
 				  {
 				    "code": "invalid_format",
 				    "format": "url",
 				    "path": [
 				      "appURL"
 				    ],
-				    "message": "Invalid URL"
+				    "message": "Invalid input"
 				  },
 				  {
 				    "expected": "object",
@@ -263,7 +263,7 @@ describe("ConfigBuilder", () => {
 				    "path": [
 				      "api"
 				    ],
-				    "message": "Invalid input: expected object, received undefined"
+				    "message": "Invalid input"
 				  }
 				]]
 			`);

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { z } from "zod/v4";
+import { z } from "zod/mini";
 import { ConfigBuilder, type ConfigBuilderOptions } from "./config-builder";
 import { ConfigParser } from "./parser/config-parser";
 import { EnvironmentVariableSource } from "./sources/env-var";
@@ -9,7 +9,7 @@ import { ObjectSource } from "./sources/object";
 const Schema = z.object({
 	appURL: z.url(),
 	api: z.object({
-		port: z.coerce.number().int().positive(),
+		port: z.coerce.number().check(z.int(), z.positive()),
 	}),
 });
 type Schema = z.infer<typeof Schema>;
@@ -152,7 +152,7 @@ describe("ConfigBuilder", () => {
 				const schemaInsideValidate = z.object({
 					appURL: z.url(),
 					api: z.object({
-						port: z.coerce.number().int().positive(),
+						port: z.coerce.number().check(z.int(), z.positive()),
 					}),
 				});
 
@@ -338,7 +338,7 @@ describe("ConfigBuilder", () => {
 				validate: (finalConfig, z) => {
 					const schema = z.object({
 						appURL: z.url(),
-						port: z.coerce.number().int().positive(),
+						port: z.coerce.number().check(z.int(), z.positive()),
 					});
 
 					return schema.parse(finalConfig);
@@ -364,7 +364,7 @@ describe("ConfigBuilder", () => {
 		function getConfig(options?: Partial<ConfigBuilderOptions>) {
 			const schema = z.object({
 				appURL: z.url(),
-				port: z.coerce.number().positive().int(),
+				port: z.coerce.number().check(z.positive(), z.int()),
 			});
 
 			return new ConfigBuilder({
@@ -406,7 +406,7 @@ describe("ConfigBuilder", () => {
 
 			const schema = z.object({
 				appURL: z.url(),
-				port: z.coerce.number().positive().int(),
+				port: z.coerce.number().check(z.positive(), z.int()),
 				host: z.string(),
 			});
 
@@ -449,7 +449,7 @@ function getConfig(options?: Partial<ConfigBuilderOptions>) {
 	const schema = z.object({
 		appURL: z.url(),
 		api: z.object({
-			port: z.coerce.number().int().positive(),
+			port: z.coerce.number().check(z.int(), z.positive()),
 		}),
 	});
 

--- a/packages/config/src/config-builder.ts
+++ b/packages/config/src/config-builder.ts
@@ -1,4 +1,4 @@
-import { z as zod } from "zod/v4";
+import { z as zod } from "zod/mini";
 import type { ConfigParser } from "./parser/config-parser";
 import { basicJsonParser } from "./parser/parser-json";
 import { Source } from "./sources/source";
@@ -10,7 +10,7 @@ export interface ConfigBuilderOptions<
 	/**
 	 * A function to validate the configuration object.
 	 * @param config - The configuration object to be validated
-	 * @param z - The zod 4 instance
+	 * @param z - The zod 4-mini instance
 	 */
 	validate: (config: Record<string, unknown>, z: typeof zod) => T;
 	/**

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,3 @@
-export { z } from "zod/v4";
+export { z } from "zod/mini";
 export * from "./config-builder";
 export * from "./parser/config-parser";

--- a/packages/config/src/sources/env-var.ts
+++ b/packages/config/src/sources/env-var.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod/mini";
 import { set } from "../utils/set";
 import { type LoadSourceOptions, Source } from "./source";
 
@@ -7,25 +7,26 @@ const EnvironmentVariableSourceOptions = z.object({
 	 * The environment variable prefix to use
 	 * @default 'APP
 	 */
-	prefix: z.string().optional().default("APP"),
+	prefix: z._default(z.optional(z.string()), "APP"),
 	/**
 	 * The separator to use between the prefix and the key
 	 * @default '_'
 	 */
-	prefixSeparator: z.string().optional().default("_"),
+	prefixSeparator: z._default(z.optional(z.string()), "_"),
 	/**
 	 * The separator to navigate the object
 	 * @default '__'
 	 */
-	separator: z.string().optional().default("__"),
+	separator: z._default(z.optional(z.string()), "__"),
 });
 
-type EnvironmentVariableSourceOptions = z.Infer<
+type EnvironmentVariableSourceOptions = z.output<
 	typeof EnvironmentVariableSourceOptions
 >;
-const PartialEnvironmentVariableSourceOptions =
-	EnvironmentVariableSourceOptions.partial();
-export type PartialEnvironmentVariableSourceOptions = z.Infer<
+const PartialEnvironmentVariableSourceOptions = z.partial(
+	EnvironmentVariableSourceOptions,
+);
+export type PartialEnvironmentVariableSourceOptions = z.output<
 	typeof PartialEnvironmentVariableSourceOptions
 >;
 

--- a/packages/config/src/sources/object.test.ts
+++ b/packages/config/src/sources/object.test.ts
@@ -1,5 +1,5 @@
 import { assertType, describe, expect, it } from "vitest";
-import { z } from "zod/v4";
+import { z } from "zod/mini";
 import { basicJsonParser } from "../parser/parser-json";
 import { ObjectSource } from "./object";
 import type { LoadSourceOptions } from "./source";
@@ -42,7 +42,7 @@ describe("ObjectSource", () => {
 
 	it("should not TS error if the type is different from the schema", () => {
 		const schema = z.object({
-			port: z.coerce.number().int().positive(),
+			port: z.coerce.number().check(z.int(), z.positive()),
 			nested: z.object({
 				foo: z.coerce.boolean(),
 			}),

--- a/packages/config/src/utils/read-if-exist.ts
+++ b/packages/config/src/utils/read-if-exist.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { z } from "zod";
+import { z } from "zod/mini";
 
 import type { Result } from "../types";
 


### PR DESCRIPTION
> relate #120 

This pull request updates the `zod` dependency from version 3 to version 4, specifically using the `zod/mini` variant, and adjusts related code to accommodate changes in the library's API. The changes span multiple files, including tests, configuration builders, and source utilities, ensuring compatibility with the updated `zod` version.

### Dependency Update and Import Adjustments:
- Updated `zod` dependency in `packages/config/package.json` from `^3.25.67` to `^4.0.10`.
- Replaced `zod/v4` imports with `zod/mini` in multiple files, including `config-builder.ts`, `index.ts`, `env-var.ts`, `object.test.ts`, and `read-if-exist.ts`. [[1]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L2-R2) [[2]](diffhunk://#diff-fe57f2f603720d0643cf99a15e4355fe4611277dd44a0533a32afa69508859f3L1-R1) [[3]](diffhunk://#diff-2eafc75a9015704b121dff9585728616f562e1625da9a53e44a86cacb94ae619L1-R1) [[4]](diffhunk://#diff-c42b8f7d4d9256e492ae3aaedf4322b7a53ef9dc88b03870c8c1504abaf2f823L1-R1) [[5]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL2-R2) [[6]](diffhunk://#diff-f0512757ae22dd4e1ad64b05b685b69403a99b2504f167aac75a8e394730a5a9L2-R2)

### API Adjustments:
- Replaced `z.int().positive()` with `z.check(z.int(), z.positive())` for validating numbers in configuration schemas across various files, including tests and documentation. [[1]](diffhunk://#diff-a8cc9c00fd3a6a4b1255df6e0ccfa80b3d378f9efbfc2f44243e5a092ce9c7a4L124-R124) [[2]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L12-R12) [[3]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L150-R150) [[4]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L336-R336) [[5]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L362-R362) [[6]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L404-R404) [[7]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L447-R447) [[8]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL45-R45)
- Updated `z.string().optional().default()` to `z._default(z.optional(z.string()), value)` for defining default values in `EnvironmentVariableSourceOptions`.

### Documentation Updates:
- Adjusted `zod` import in code examples within documentation files to align with the new version (`zod` instead of `zod/v4`). [[1]](diffhunk://#diff-24af9485c660d876897e3cb52338cf75e78de122faaf6da8692f632773571b83L11-R11) [[2]](diffhunk://#diff-a8cc9c00fd3a6a4b1255df6e0ccfa80b3d378f9efbfc2f44243e5a092ce9c7a4L124-R124)

### Test Updates:
- Modified tests to use the updated `zod/mini` imports and adjusted validation logic to reflect API changes. [[1]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L2-R2) [[2]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L12-R12) [[3]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L150-R150) [[4]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L336-R336) [[5]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L362-R362) [[6]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L404-R404) [[7]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L447-R447) [[8]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL2-R2) [[9]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL45-R45)

These updates ensure compatibility with the latest version of `zod` while maintaining the integrity of the configuration and validation logic.