### PR TITLE
Export zod and zod-mini as sub modules

### DIFF
--- a/.changeset/stupid-carpets-find.md
+++ b/.changeset/stupid-carpets-find.md
@@ -1,0 +1,54 @@
+---
+"@layerfig/config": major
+---
+
+BREAKING CHANGE: upgrade zod dependency to v4 and ship the `mini` version.
+
+### Details
+
+We give access to `z` (zod) to users so they don't need to bring a schema validator only for setting the configuration.
+
+```ts
+export const config = new ConfigBuilder({
+  validate: (finalConfig, z) =>
+    z.object({
+        appURL: z.url(),
+        port: z.coerce.number().int().int().positive(),
+      })
+      .parse(finalConfig),
+})
+  .addSource(new FileSource("base.json"))
+  .build();
+```
+
+The problem is that we provided the "big" version of zod which can go from 5.91kb to 13.1kb (gzip), which if you're using only for server it's fine but if you're using the client approach it'll be a huge bundle.
+
+Now, `z` is no longer regular zod but the [`mini`](https://zod.dev/packages/mini) version of it, which changes how to define the schema:
+
+```diff
+-z.string().optional().default("APP")
++z._default(z.optional(z.string()), "APP")
+
+
+-schema.partial()
++z.partial(schema)
+
+-z.coerce.number().int().positive()
++z.coerce.number().check(z.int(), z.positive()),
+```
+
+Also, before you could import `z` from the main entrypoint:
+
+```ts
+import { z } from "@layerfig/config"
+```
+
+Now we provide two other sub-modules: `zod` and `zod-mini`
+
+```ts
+// full zod 4
+import { z } from "@layerfig/config/zod"
+
+// zod 4 mini
+import { z } from "@layerfig/config/zod-mini"
+```

--- a/docs/src/content/docs/getting-started/base-files.astro
+++ b/docs/src/content/docs/getting-started/base-files.astro
@@ -19,7 +19,7 @@ export const config = new ConfigBuilder({
   validate: (finalConfig, z) =>
     z.object({
         appURL: z.url(),
-        port: z.coerce.number().int().int().positive(),
+        port: z.coerce.number().check(z.int(), z.positive()),
       })
       .parse(finalConfig),
 })

--- a/docs/src/content/docs/guides/client-config.mdx
+++ b/docs/src/content/docs/guides/client-config.mdx
@@ -2,6 +2,8 @@
 title: Client Configuration
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 Layerfig was originally designed to work on the server side. This is because it relies on configuration files that you commit (which use Node.js APIs) or on environment variables accessed via `process.env`.
 
 We don't recommend using Layerfig solely for client-side configuration, as this can be accomplished with only a schema validation library like Zod:

--- a/docs/src/content/docs/guides/client-config.mdx
+++ b/docs/src/content/docs/guides/client-config.mdx
@@ -8,7 +8,7 @@ We don't recommend using Layerfig solely for client-side configuration, as this 
 
 ```ts
 // client-config.ts
-import { z } from "zod";
+import { z } from "zod/mini";
 
 const schema = z.object({
   appURL: z.url(),
@@ -27,14 +27,15 @@ The advantage of this approach is that you can have separate `server-config.ts`,
 
 ```ts
 // client-config.ts
-import { ConfigBuilder, z } from "@layerfig/config";
+import { ConfigBuilder } from "@layerfig/config";
+import { z } from "@layerfig/config/zod-mini";
 import { ObjectSource } from "@layerfig/config/sources/object";
 import { configSchema } from "./schema";
 
 const ClientSchema = configSchema.pick({
   appURL: true,
 });
-type ClientSchema = z.infer<typeof ClientSchema>;
+type ClientSchema = z.output<typeof ClientSchema>;
 
 export const config = new ConfigBuilder({
   validate: (finalConfig) => ClientSchema.parse(finalConfig),
@@ -47,3 +48,8 @@ export const config = new ConfigBuilder({
   )
   .build();
 ```
+
+<Aside>
+  [Zod mini](https://zod.dev/packages/mini) is recommended for client versions
+  since it ships a smaller bundle of zod.
+</Aside>

--- a/docs/src/content/docs/introduction.mdx
+++ b/docs/src/content/docs/introduction.mdx
@@ -60,16 +60,17 @@ When using `ConfigBuilder`, configuration is loaded from two primary sources:
 Since the configuration follows a cascading approach, the final result depends on the order in which sources are added.
 
 ```ts
-import { ConfigBuilder, z } from "@layerfig/config";
+import { ConfigBuilder } from "@layerfig/config";
 import { FileSource } from "@layerfig/config/sources/file";
 import { EnvironmentVariableSource } from "@layerfig/config/sources/env";
 
-const schema = z.object({
-  baseURL: z.url(),
-});
-
 export const config = new ConfigBuilder({
-  validate: (finalConfig) => schema.parse(finalConfig),
+  validate: (finalConfig, z) =>
+    z
+      .object({
+        baseURL: z.url(),
+      })
+      .parse(finalConfig),
 })
   //  1. Starts with a base configuration.
   .addSource(new FileSource("base.json"))

--- a/docs/src/content/docs/setup/configuration.mdx
+++ b/docs/src/content/docs/setup/configuration.mdx
@@ -12,7 +12,7 @@ The `ConfigBuilder` constructor requires a `validate` function. This function re
 import { ConfigBuilder } from "@layerfig/config";
 import { FileSource } from "@layerfig/config/sources/file";
 
-// config will be type `z.infer<typeof schema>` (the actual object type)
+// config will be type `z.output<typeof schema>` (the actual object type)
 export const config = new ConfigBuilder({
   validate: (finalConfig, z) => {
     const schema = z.object({

--- a/docs/src/content/docs/setup/slots.mdx
+++ b/docs/src/content/docs/setup/slots.mdx
@@ -60,7 +60,7 @@ const finalConfig = {
 To handle this, you can use a validation schema to coerce the string value into a number. For example, with Zod:
 
 ```ts {5}
-import { z } from "@layerfig/config";
+import { z } from "@layerfig/config/zod";
 
 const schema = z.object({
   appURL: z.string(),

--- a/docs/src/content/docs/setup/sources.mdx
+++ b/docs/src/content/docs/setup/sources.mdx
@@ -146,7 +146,8 @@ Since the environment variable source is added last, its values take precedence.
 Use `__` (double underscores) as a separator to target nested keys:
 
 ```ts
-import { ConfigBuilder, z } from "@layerfig/config";
+import { ConfigBuilder } from "@layerfig/config";
+import { z } from "@layerfig/config/zod";
 import { FileSource } from "@layerfig/config/sources/file";
 import { EnvironmentVariableSource } from "@layerfig/config/sources/env";
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,6 +49,26 @@
 				"types": "./dist/sources/*/index.d.cts",
 				"default": "./dist/sources/*/index.cjs"
 			}
+		},
+		"./zod": {
+			"import": {
+				"types": "./dist/zod.d.ts",
+				"default": "./dist/zod.js"
+			},
+			"require": {
+				"types": "./dist/zod.d.cts",
+				"default": "./dist/zod.cjs"
+			}
+		},
+		"./zod-mini": {
+			"import": {
+				"types": "./dist/zod-mini.d.ts",
+				"default": "./dist/zod-mini.js"
+			},
+			"require": {
+				"types": "./dist/zod-mini.d.cts",
+				"default": "./dist/zod-mini.cjs"
+			}
 		}
 	},
 	"scripts": {

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { z } from "zod/mini";
 import { ConfigBuilder, type ConfigBuilderOptions } from "./config-builder";
 import { ConfigParser } from "./parser/config-parser";
 import { EnvironmentVariableSource } from "./sources/env-var";
 import { FileSource } from "./sources/file";
 import { ObjectSource } from "./sources/object";
+import { z } from "./zod-mini";
 
 const Schema = z.object({
 	appURL: z.url(),
@@ -12,7 +12,7 @@ const Schema = z.object({
 		port: z.coerce.number().check(z.int(), z.positive()),
 	}),
 });
-type Schema = z.infer<typeof Schema>;
+type Schema = z.output<typeof Schema>;
 
 const baseConfigBuilderOptions: ConfigBuilderOptions = {
 	validate: (finalConfig) => {

--- a/packages/config/src/config-builder.ts
+++ b/packages/config/src/config-builder.ts
@@ -1,8 +1,8 @@
-import { z as zod } from "zod/mini";
 import type { ConfigParser } from "./parser/config-parser";
 import { basicJsonParser } from "./parser/parser-json";
 import { Source } from "./sources/source";
 import { merge } from "./utils";
+import { z as zod } from "./zod-mini";
 
 export interface ConfigBuilderOptions<
 	T extends object = Record<string, unknown>,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,2 @@
-export { z } from "zod/mini";
 export * from "./config-builder";
 export * from "./parser/config-parser";

--- a/packages/config/src/sources/env-var.ts
+++ b/packages/config/src/sources/env-var.ts
@@ -1,5 +1,5 @@
-import { z } from "zod/mini";
 import { set } from "../utils/set";
+import { z } from "../zod-mini";
 import { type LoadSourceOptions, Source } from "./source";
 
 const EnvironmentVariableSourceOptions = z.object({

--- a/packages/config/src/sources/object.test.ts
+++ b/packages/config/src/sources/object.test.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expect, it } from "vitest";
-import { z } from "zod/mini";
 import { basicJsonParser } from "../parser/parser-json";
+import { z } from "../zod-mini";
 import { ObjectSource } from "./object";
 import type { LoadSourceOptions } from "./source";
 
@@ -48,7 +48,7 @@ describe("ObjectSource", () => {
 			}),
 		});
 
-		type Schema = z.infer<typeof schema>;
+		type Schema = z.output<typeof schema>;
 
 		new ObjectSource<Schema>({
 			port: "$PORT",

--- a/packages/config/src/utils/read-if-exist.ts
+++ b/packages/config/src/utils/read-if-exist.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
-import { z } from "zod/mini";
-
 import type { Result } from "../types";
+import { z } from "../zod-mini";
 
 export function readIfExist(filePath: string): Result<string, string> {
 	if (fs.existsSync(filePath)) {

--- a/packages/config/src/zod-mini.ts
+++ b/packages/config/src/zod-mini.ts
@@ -1,0 +1,1 @@
+export * from "zod/mini";

--- a/packages/config/src/zod.ts
+++ b/packages/config/src/zod.ts
@@ -1,0 +1,1 @@
+export * from "zod";

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
 		"sources/env/index": "./src/sources/env-var.ts",
 		"sources/file/index": "./src/sources/file.ts",
 		"sources/object/index": "./src/sources/object.ts",
+		zod: "./src/zod.ts",
+		"zod-mini": "./src/zod-mini.ts",
 	},
 	dts: true,
 	sourcemap: true,


### PR DESCRIPTION
This pull request introduces a breaking change to the `@layerfig/config` package by upgrading the `zod` dependency to version 4 and switching to the `mini` version of `zod` for client-side configurations. It also updates documentation and code to reflect the new schema validation approach and adds sub-module support for both full and mini versions of `zod`. Below are the most important changes grouped by theme:

### Breaking Changes and Feature Enhancements:
* Upgraded `zod` dependency to version 4 and switched to the `mini` version for lighter client-side bundles. Updated schema definitions to accommodate `zod-mini` syntax changes.
* Added sub-modules `zod` and `zod-mini` to the package, allowing users to choose between the full or mini versions of `zod` explicitly [[1]](diffhunk://#diff-fd956f6d78d80e1989716c00afb66f1ac64847e9b4a3673def6f483cd218e963R52-R71) [[2]](diffhunk://#diff-faf7375ada8e0e2c0dd588a8ed39804cdf46c61589573b416456c37d28728099R1) [[3]](diffhunk://#diff-740f155d4d61856fa8ab4da22b2e5b1a7cf5552242c6205c8ff41a83e3039500R1).

### Documentation Updates:
* Updated examples in the documentation to use `zod-mini` for client-side configurations and added an aside recommending its use for smaller bundles [[1]](diffhunk://#diff-24af9485c660d876897e3cb52338cf75e78de122faaf6da8692f632773571b83L11-R11) [[2]](diffhunk://#diff-24af9485c660d876897e3cb52338cf75e78de122faaf6da8692f632773571b83L30-R38) [[3]](diffhunk://#diff-24af9485c660d876897e3cb52338cf75e78de122faaf6da8692f632773571b83R51-R55).
* Revised type inference examples to use `z.output` instead of `z.infer` for compatibility with `zod-mini` [[1]](diffhunk://#diff-8a85d9f41e5e5fa8ddeea9463f70a9fb0ce8d0f6923fb4e6c715d1e62ed0b98cL15-R15) [[2]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL51-R51).

### Codebase Refactoring:
* Replaced imports of `zod/mini` with local imports of `zod-mini` across source files and tests to align with the new sub-module structure [[1]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L2-R15) [[2]](diffhunk://#diff-fe57f2f603720d0643cf99a15e4355fe4611277dd44a0533a32afa69508859f3L1-R5) [[3]](diffhunk://#diff-c42b8f7d4d9256e492ae3aaedf4322b7a53ef9dc88b03870c8c1504abaf2f823L1-R2) [[4]](diffhunk://#diff-fdabb77f10bff8f163c6624d399536424e1e254bc8eeba965f579cc01761835fL2-R3) [[5]](diffhunk://#diff-f0512757ae22dd4e1ad64b05b685b69403a99b2504f167aac75a8e394730a5a9L2-R3).
* Added `zod.ts` and `zod-mini.ts` files to export respective versions of `zod` [[1]](diffhunk://#diff-faf7375ada8e0e2c0dd588a8ed39804cdf46c61589573b416456c37d28728099R1) [[2]](diffhunk://#diff-740f155d4d61856fa8ab4da22b2e5b1a7cf5552242c6205c8ff41a83e3039500R1).

### Build Configuration:
* Updated `tsdown.config.ts` to include mappings for `zod` and `zod-mini` modules.