### PR TITLE
Refactor slot logic

### DIFF
--- a/.changeset/busy-rooms-sell.md
+++ b/.changeset/busy-rooms-sell.md
@@ -1,0 +1,59 @@
+---
+"@layerfig/config": major
+---
+
+BREAKING CHANGE: refactor slot syntax.
+
+### Changes
+
+Simple slots needs to be wrapped by `${}`:
+
+```diff
+{
+- "port": "$PORT"
++ "port": "${PORT}"
+}
+```
+
+Slot separator changed from `:` to `::`:
+
+```diff
+{
+- "port": "${APP_PORT:PORT}"
++ "port": "${APP_PORT::PORT}"
+}
+```
+
+### Fixes
+
+#### URL case
+
+If a slot contained an URL, it didn't resolve properly the fallback value:
+
+Before:
+
+```
+${URL:-http://localhost:3000} => "//localhost:3000"
+```
+
+After:
+
+```
+${URL::-http://localhost:3000} => "http://localhost:3000"
+```
+
+#### Multiple slots
+
+When multiple slots were defined in the same property, the final value didn't get resolved:
+
+Before:
+
+```
+${self.hostname:-local}:${PORT:-3000} => "local:${PORT:-3000}"
+```
+
+Now:
+
+```
+${self.hostname::-local}:${PORT::-3000} => "local:3000"
+```

--- a/.changeset/funny-impalas-study.md
+++ b/.changeset/funny-impalas-study.md
@@ -1,0 +1,5 @@
+---
+"@layerfig/config": patch
+---
+
+Update zod to v4.0.17

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Debug Config Tests",
+			"type": "node",
+			"request": "launch",
+			"runtimeExecutable": "bun",
+			"runtimeArgs": ["--inspect-wait", "run", "test"],
+			"cwd": "${workspaceFolder}/packages/config",
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen",
+			"skipFiles": ["<node_internals>/**"],
+			"env": {
+				"NODE_ENV": "test"
+			}
+		}
+	]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "layerfig",
       "devDependencies": {
-        "@biomejs/biome": "2.1.2",
+        "@biomejs/biome": "2.1.4",
         "@changesets/cli": "2.29.5",
         "husky": "9.1.7",
         "lint-staged": "16.1.2",
@@ -16,7 +16,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/starlight": "0.34.4",
-        "@layerfig/config": "3.0.0-next.2",
+        "@layerfig/config": "3.0.0-next.5",
         "@layerfig/parser-yaml": "6.0.0-next.0",
         "astro": "5.10.1",
         "sharp": "0.34.2",
@@ -29,7 +29,7 @@
       "version": "3.0.0-next.5",
       "dependencies": {
         "es-toolkit": "^1.39.8",
-        "zod": "^4.0.10",
+        "zod": "^4.0.17",
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
@@ -180,23 +180,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.1.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.1.2", "@biomejs/cli-darwin-x64": "2.1.2", "@biomejs/cli-linux-arm64": "2.1.2", "@biomejs/cli-linux-arm64-musl": "2.1.2", "@biomejs/cli-linux-x64": "2.1.2", "@biomejs/cli-linux-x64-musl": "2.1.2", "@biomejs/cli-win32-arm64": "2.1.2", "@biomejs/cli-win32-x64": "2.1.2" }, "bin": { "biome": "bin/biome" } }, "sha512-yq8ZZuKuBVDgAS76LWCfFKHSYIAgqkxVB3mGVVpOe2vSkUTs7xG46zXZeNPRNVjiJuw0SZ3+J2rXiYx0RUpfGg=="],
+    "@biomejs/biome": ["@biomejs/biome@2.1.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.1.4", "@biomejs/cli-darwin-x64": "2.1.4", "@biomejs/cli-linux-arm64": "2.1.4", "@biomejs/cli-linux-arm64-musl": "2.1.4", "@biomejs/cli-linux-x64": "2.1.4", "@biomejs/cli-linux-x64-musl": "2.1.4", "@biomejs/cli-win32-arm64": "2.1.4", "@biomejs/cli-win32-x64": "2.1.4" }, "bin": { "biome": "bin/biome" } }, "sha512-QWlrqyxsU0FCebuMnkvBIkxvPqH89afiJzjMl+z67ybutse590jgeaFdDurE9XYtzpjRGTI1tlUZPGWmbKsElA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-leFAks64PEIjc7MY/cLjE8u5OcfBKkcDB0szxsWUB4aDfemBep1WVKt0qrEyqZBOW8LPHzrFMyDl3FhuuA0E7g=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sCrNENE74I9MV090Wq/9Dg7EhPudx3+5OiSoQOkIe3DLPzFARuL1dOwCWhKCpA3I5RHmbrsbNSRfZwCabwd8Qg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Nmmv7wRX5Nj7lGmz0FjnWdflJg4zii8Ivruas6PBKzw5SJX/q+Zh2RfnO+bBnuKLXpj8kiI2x2X12otpH6a32A=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-gOEICJbTCy6iruBywBDcG4X5rHMbqCPs3clh3UQ+hRKlgvJTk4NHWQAyHOXvaLe+AxD1/TNX1jbZeffBJzcrOw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-juhEkdkKR4nbUi5k/KRp1ocGPNWLgFRD4NrHZSveYrD6i98pyvuzmS9yFYgOZa5JhaVqo0HPnci0+YuzSwT2fw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-qgHvafhjH7Oca114FdOScmIKf1DlXT1LqbOrrbR30kQDLFPEOpBG0uzx6MhmsrmhGiCFCr2obDamu+czk+X0HQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-nYr7H0CyAJPaLupFE2cH16KZmRC5Z9PEftiA2vWxk+CsFkPZQ6dBRdcC6RuS+zJlPc/JOd8xw3uCCt9Pv41WvQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Eoy9ycbhpJVYuR+LskV9s3uyaIkp89+qqgqhGQsWnp/I02Uqg2fXFblHJOpGZR8AxdB9ADy87oFVxn9MpFKUrw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lvwvb2SQQHctHUKvBKptR6PLFCM7JfRjpCCrDaTmvB7EeZ5/dQJPhTYBf36BE/B4CRWR2ZiBLRYhK7hhXBCZAg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.1.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3WRYte7orvyi6TRfIZkDN9Jzoogbv+gSvR+b9VOXUg1We1XrjBg6WljADeVEaKTvOcpVdH0a90TwyOQ6ue4fGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9zajnk59PMpjBkty3bK2IrjUsUHvqe9HWwyAWQBjGLE7MIBjbX2vwv1XPEhmO2RRuGoTkVx3WCanHrjAytICLA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-tBc+W7anBPSFXGAoQW+f/+svkpt8/uXfRwDzN1DvnatkRMt16KIYpEi/iw8u9GahJlFv98kgHcIrSsZHZTR0sw=="],
 
     "@braidai/lang": ["@braidai/lang@1.1.1", "", {}, "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg=="],
 
@@ -780,7 +780,7 @@
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
-    "es-toolkit": ["es-toolkit@1.39.8", "", {}, "sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg=="],
+    "es-toolkit": ["es-toolkit@1.39.10", "", {}, "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1476,7 +1476,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typescript": ["typescript@5.9.0-beta", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p91qoTdwWKj9YEBYavmGiBn0DF4OBElzw4pW4oPbK4HeCfr/SDz9+yviVWshZXGvGvFCJ3AVQ+J7F1UZXc23QQ=="],
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
@@ -1574,7 +1574,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.1", "", {}, "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="],
 
-    "zod": ["zod@4.0.10", "", {}, "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA=="],
+    "zod": ["zod@4.0.17", "", {}, "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
@@ -1617,10 +1617,6 @@
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
-
-    "@shikijs/twoslash/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
-    "@typescript/vfs/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1672,8 +1668,6 @@
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
-    "rolldown-plugin-dts/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
     "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
@@ -1683,12 +1677,6 @@
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "tsconfck/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
-    "tsdown/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
-    "twoslash/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "unstorage/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1705,8 +1693,6 @@
     "yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "zod-to-json-schema/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
-
-    "zod-to-ts/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "zod-to-ts/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
 

--- a/docs/config/base.yaml
+++ b/docs/config/base.yaml
@@ -1,2 +1,2 @@
-branchName: ${WORKERS_CI_BRANCH:GITHUB_REF:-main}
-editLink: https://github.com/raulfdm/layerfig/tree/${WORKERS_CI_BRANCH:GITHUB_REF:-main}/docs
+branchName: ${WORKERS_CI_BRANCH::GITHUB_REF::-main}
+editLink: https://github.com/raulfdm/layerfig/tree/${WORKERS_CI_BRANCH::GITHUB_REF::-main}/docs

--- a/docs/src/content/docs/migrate-to-v3.mdx
+++ b/docs/src/content/docs/migrate-to-v3.mdx
@@ -122,6 +122,39 @@ For server-side code, you can still import everything from the main module:
 import { ConfigBuilder } from "@layerfig/config";
 ```
 
+### Slots syntax
+
+In v2, slots could be defined in a few ways:
+
+- `$PORT` => it would get `process.env.PORT`
+- `${APP_PORT:PORT}` => it would try to resolve `process.env.APP_PORT` and if not found, `process.env.PORT`
+- `${APP_PORT:PORT:3000}` => same but if both not found, fallback to `3000`
+- `${self.port}` => reference to the `.port` value of the config
+
+This strategy made unnecessarily complex and error prone to define what is a slot and split the values inside.
+
+Now, every slot needs to be wrapped by `${}` (or defining your own slotPrefix, e.g., `#{}`, `@{}`, etc.).
+
+```diff
+-port: $PORT
++port: ${PORT}
+```
+
+Also, when channing values, instead using single colon (`:`) to separate the values, you must use double colon (`::`):
+
+```diff
+-port: ${APP_PORT:PORT:-3000}
++port: ${APP_PORT::PORT::-3000}
+```
+
+This refactor now allow you to specify more complex cases, such as multiple slots in the same value:
+
+```yaml
+host:
+  ${HOST::-localhost}:${self.port::-3000}
+  # 👆🏽 gets resolved to `localhost:3000` if neither `HOST` nor `self.port` are defined
+```
+
 ---
 
 ## Other Changes

--- a/docs/src/content/docs/setup/slots.mdx
+++ b/docs/src/content/docs/setup/slots.mdx
@@ -27,8 +27,8 @@ To reference this environment variable, you can use a "slot":
 ```json
 // config/base.json
 {
-  "appURL": "http://localhost:$PORT",
-  "port": "$PORT"
+  "appURL": "http://localhost:${PORT}",
+  "port": "${PORT}"
 }
 ```
 
@@ -50,11 +50,11 @@ In the previous "port" example, instead of defining the `$PORT` slot in two plac
 // config/base.json
 {
   "appURL": "http://localhost:${self.port}",
-  "port": "${PORT:-3000}"
+  "port": "${PORT::-3000}"
 }
 ```
 
-Layerfig searches for the `${self.*}` syntax in the configuration file and uses the value after the dot as an "object-path" to find the value in the same configuration. In this case, it will look for the `port` value.
+Layerfig searches for the `self.*` syntax in the configuration file and uses the value after the dot as an "object-path" to find the value in the same configuration. In this case, it will look for the `port` value.
 
 The final configuration will be:
 
@@ -78,18 +78,18 @@ By default, Layerfig uses `$` as the slot prefix, but you can change it by passi
 
 You may want to try multiple environment variables for a single value, providing a chain of options in a specific order of priority.
 
-For example, imagine you want to determine the current Git branch. This value could be sourced from several environment variables:
+For example, imagine you want to determine the current Git branch. This value could be sourced different sources:
 
 1.  `process.env.GIT_REF`
 2.  `process.env.REF`
-3.  `process.env.MAIN_REF`
+3.  `.branch` (from the same configuration file)
 
 To achieve this, you can use the extended slot syntax, separating each variable name with a colon:
 
 ```json
 // config/base.json
 {
-  "branch": "${GIT_REF:REF:MAIN_REF}"
+  "branch": "${GIT_REF::REF::self.branch}"
 }
 ```
 
@@ -104,7 +104,7 @@ This is achieved by adding the `:-` operator to the extended slot syntax. This w
 ```json
 // config/base.json
 {
-  "port": "${PORT:-3000}"
+  "port": "${PORT::-3000}"
 }
 ```
 
@@ -115,7 +115,7 @@ This operator can be combined with variable chaining for more complex cases:
 ```json
 // config/base.json
 {
-  "branch": "${GIT_REF:REF:MAIN_REF:-main}"
+  "branch": "${GIT_REF::REF::MAIN_REF::-main}"
 }
 ```
 
@@ -125,10 +125,32 @@ If none of the `GIT_REF`, `REF`, or `MAIN_REF` environment variables are found, 
 
 There are a few things to keep in mind when working with slots.
 
-If an environment variable for a slot is not defined, Layerfig will not perform a replacement. The configuration value will retain the original slot string:
+If an environment variable for a slot is not defined, Layerfig will perform a replacement with `undefined` value. The configuration value will retain the original slot string:
 
 ```ts
-config.appURL; // "http://localhost:$PORT"
+config.appURL; // undefined
+```
+
+In this case, if your schema does expect a defined value, it would throw an error during validation. Also, for array items, if value gets resolved to undefined it'll be removed.
+
+For example, let's say we only have `ORIGIN_1` defined in our environment variables.
+
+```
+ORIGIN_1=*
+```
+
+The following config:
+
+```
+allowOrigins: ["${ORIGIN_1}", "${ORIGIN_2}"]
+```
+
+Will be resolved to:
+
+```ts
+const config = {
+  allowOrigins: ["*"], // ORIGIN_2 got discarded.
+};
 ```
 
 Additionally, all environment variables are treated as strings. If a slot is used for a value that should be a number, like `port`, the resulting configuration will have a string value:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "layerfig",
 	"version": "0.0.0-development",
 	"private": true,
+	"type": "module",
 	"packageManager": "bun@1.2.19",
 	"workspaces": [
 		"packages/*",
@@ -18,7 +19,7 @@
 		"prepare": "husky"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.1.2",
+		"@biomejs/biome": "2.1.4",
 		"@changesets/cli": "2.29.5",
 		"husky": "9.1.7",
 		"lint-staged": "16.1.2",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -79,7 +79,7 @@
 	},
 	"dependencies": {
 		"es-toolkit": "^1.39.8",
-		"zod": "^4.0.10"
+		"zod": "^4.0.17"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "0.18.2",

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -95,6 +95,7 @@ describe.each(builders)(
 								allowedOrigins: [
 									"${CORS_ORIGIN1::-*}",
 									"${CORS_ORIGIN2::-https://example.com}",
+									"${CORS_ORIGIN3}",
 								],
 								allowedMethods: ["GET", "POST", "PUT", "DELETE"],
 							},
@@ -220,6 +221,29 @@ describe.each(builders)(
 						.build(),
 				).toEqual({
 					host: undefined,
+				});
+			});
+
+			it("should remove undefined from array", () => {
+				expect(
+					new ConfigBuilder({
+						validate: (finalConfig) => finalConfig,
+						runtimeEnv: {
+							CORS_ORIGIN2: "https://example.com",
+						},
+					})
+						.addSource(
+							new ObjectSource({
+								hosts: [
+									"${CORS_ORIGIN1}",
+									"${CORS_ORIGIN2}",
+									"${CORS_ORIGIN3}",
+								],
+							}),
+						)
+						.build(),
+				).toEqual({
+					hosts: ["https://example.com"],
 				});
 			});
 

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { assertType, describe, expect, it, vi } from "vitest";
+import { assertType, describe, expect, it } from "vitest";
 import * as ClientModule from "./client";
 import { basicJsonParser } from "./parser/parser-json";
 import * as ServerModule from "./server";
@@ -19,8 +19,155 @@ const builders = [
 describe.each(builders)(
 	"[Shared Features] ConfigBuilder ($mode)",
 	({ ConfigBuilder }) => {
-		describe("basic slot", () => {
-			it("should replace basic slots", () => {
+		it("should build config correctly (complex case)", () => {
+			const config = new ConfigBuilder({
+				validate: (finalConfig) => finalConfig,
+				runtimeEnv: {
+					DB_PASS: "supersecret",
+					DB_POOL_MAX: "20",
+					HOSTNAME: "app.example.com",
+					LOG_LEVEL: "debug",
+					METRICS_ENABLED: "true",
+					PORT: "3000",
+					PRIMARY_DB_HOST: "primary.db.example.com",
+					PROTOCOL: "https",
+				},
+			})
+				.addSource(
+					new ObjectSource({
+						server: {
+							port: "${PORT}",
+							hostname: "${HOSTNAME::-localhost}",
+							protocol: "${PROTOCOL::SCHEME::-http}",
+							baseUrl: "${BASE_URL::self.server.hostname}:${PORT::-8080}",
+							endpoints: [
+								{
+									name: "health",
+									path: "/health",
+									enabled: true,
+								},
+								{
+									name: "metrics",
+									path: "/metrics",
+									enabled: "${METRICS_ENABLED::-false}",
+								},
+							],
+						},
+						database: {
+							host: "${DB_HOST::PRIMARY_DB_HOST::SECONDARY_DB_HOST::-db.local}",
+							port: "${DB_PORT::-5432}",
+							user: "${DB_USER::-appuser}",
+							password: "${DB_PASS::-secret}",
+							name: "${DB_NAME::-appdb}",
+							pool: {
+								min: 2,
+								max: "${DB_POOL_MAX::-10}",
+							},
+						},
+						cache: {
+							enabled: "${CACHE_ENABLED::-true}",
+							provider: "${CACHE_PROVIDER::-redis}",
+							redis: {
+								host: "${REDIS_HOST::-localhost}",
+								port: "${REDIS_PORT::-6379}",
+								ttl: "${REDIS_TTL::-3600}",
+							},
+						},
+						logging: {
+							level: "${LOG_LEVEL::-info}",
+							file: {
+								enabled: "${LOG_FILE_ENABLED::-false}",
+								path: "${LOG_FILE_PATH::-/var/log/app.log}",
+							},
+						},
+						features: {
+							beta: "${FEATURE_BETA::-false}",
+							newUI: "${FEATURE_NEW_UI::-true}",
+							experiments: [
+								"${EXPERIMENT_A::-off}",
+								"${EXPERIMENT_B::-on}",
+								"${EXPERIMENT_C::-off}",
+							],
+						},
+						security: {
+							jwtSecret: "${JWT_SECRET::-changeme}",
+							cors: {
+								allowedOrigins: [
+									"${CORS_ORIGIN1::-*}",
+									"${CORS_ORIGIN2::-https://example.com}",
+								],
+								allowedMethods: ["GET", "POST", "PUT", "DELETE"],
+							},
+						},
+						selfReference: {
+							port: "${PORT}",
+							hostname: "${HOSTNAME::-localhost}",
+							url: "${self.selfReference.hostname}:${self.selfReference.port}",
+						},
+					}),
+				)
+				.build();
+
+			expect(config).toEqual({
+				server: {
+					port: "3000",
+					protocol: "https",
+					hostname: "app.example.com",
+					baseUrl: "app.example.com:3000",
+					endpoints: [
+						{ name: "health", path: "/health", enabled: true },
+						{ name: "metrics", path: "/metrics", enabled: "true" },
+					],
+				},
+				database: {
+					port: "5432",
+					user: "appuser",
+					host: "primary.db.example.com",
+					password: "supersecret",
+					name: "appdb",
+					pool: {
+						min: 2,
+						max: "20",
+					},
+				},
+				cache: {
+					enabled: "true",
+					provider: "redis",
+					redis: {
+						host: "localhost",
+						port: "6379",
+						ttl: "3600",
+					},
+				},
+				logging: {
+					level: "debug",
+					file: {
+						enabled: "false",
+						path: "/var/log/app.log",
+					},
+				},
+				features: {
+					beta: "false",
+					newUI: "true",
+					experiments: ["off", "on", "off"],
+				},
+				security: {
+					jwtSecret: "changeme",
+					cors: {
+						allowedOrigins: ["*", "https://example.com"],
+						allowedMethods: ["GET", "POST", "PUT", "DELETE"],
+					},
+				},
+				selfReference: {
+					port: "3000",
+					hostname: "app.example.com",
+					url: "app.example.com:3000",
+				},
+			});
+		});
+
+		describe("slots", () => {
+			it("should replace single slots", () => {
 				const schema = z.object({
 					port: z.coerce.number().int().positive(),
 					host: z.string(),
@@ -34,8 +181,8 @@ describe.each(builders)(
 				})
 					.addSource(
 						new ObjectSource({
-							port: "$PORT",
-							host: "localhost:$PORT",
+							port: "${PORT}",
+							host: "localhost:${PORT}",
 						}),
 					)
 					.build();
@@ -46,81 +193,33 @@ describe.each(builders)(
 				});
 			});
 
-			it("should replace basic slots with fallback", () => {
-				const schema = z.object({
-					port: z.coerce.number().int().positive(),
-					host: z.string(),
+			it("should replace value with undefined if env var is undefined", () => {
+				expect(
+					new ConfigBuilder({
+						validate: (finalConfig) => finalConfig,
+					})
+						.addSource(
+							new ObjectSource({
+								host: "localhost:${PORT}",
+							}),
+						)
+						.build(),
+				).toEqual({
+					host: undefined,
 				});
 
-				const config = new ConfigBuilder({
-					validate: (finalConfig) => schema.parse(finalConfig),
-				})
-					.addSource(
-						new ObjectSource({
-							port: "${PORT:-3000}",
-							host: "localhost:${PORT:-3000}",
-						}),
-					)
-					.build();
-
-				expect(config).toEqual({
-					port: 3000,
-					host: "localhost:3000",
-				});
-			});
-
-			it("should not replace value if env var is undefined and console.warn", () => {
-				const warnSpy = vi.spyOn(console, "warn");
-
-				const schema = z.object({
-					host: z.string(),
-				});
-
-				const config = new ConfigBuilder({
-					validate: (finalConfig) => schema.parse(finalConfig),
-				})
-					.addSource(
-						new ObjectSource({
-							host: "localhost:$PORT",
-						}),
-					)
-					.build();
-
-				expect(config).toEqual({
-					host: "localhost:$PORT",
-				});
-
-				expect(warnSpy).toHaveBeenCalledWith(
-					"[SINGLE_VARIABLE_SLOT]",
-					'The value for the slot "PORT" is not defined in the runtime environment. The slot will not be replaced.',
-				);
-			});
-		});
-
-		describe("multi variable slot", () => {
-			it("should replace multi variable slots", () => {
-				const schema = z.object({
-					port: z.coerce.number().int().positive(),
-					host: z.string(),
-				});
-
-				const config = new ConfigBuilder({
-					validate: (finalConfig) => schema.parse(finalConfig),
-					runtimeEnv: {
-						APP_PORT: "5432",
-					},
-				})
-					.addSource(
-						new ObjectSource({
-							port: "${PORT:APP_PORT}",
-							host: "localhost:${PORT:APP_PORT}",
-						}),
-					)
-					.build();
-
-				expect(config).toEqual({
-					port: 5432,
-					host: "localhost:5432",
+				expect(
+					new ConfigBuilder({
+						validate: (finalConfig) => finalConfig,
+					})
+						.addSource(
+							new ObjectSource({
+								host: "${PORT_1:PORT_2:PORT_3}",
+							}),
+						)
+						.build(),
+				).toEqual({
+					host: undefined,
 				});
 			});
 
@@ -145,8 +244,8 @@ describe.each(builders)(
 					})
 						.addSource(
 							new ObjectSource({
-								port: "${PORT_1:PORT_2:PORT_3}",
-								host: "localhost:${PORT_1:PORT_2:PORT_3}",
+								port: "${PORT_1::PORT_2::PORT_3}",
+								host: "localhost:${self.port}",
 							}),
 						)
 						.build(),
@@ -166,8 +265,8 @@ describe.each(builders)(
 					})
 						.addSource(
 							new ObjectSource({
-								port: "${PORT_1:PORT_2:PORT_3}",
-								host: "localhost:${PORT_1:PORT_2:PORT_3}",
+								port: "${PORT_1::PORT_2::PORT_3}",
+								host: "localhost:${PORT_1::PORT_2::PORT_3}",
 							}),
 						)
 						.build(),
@@ -187,8 +286,8 @@ describe.each(builders)(
 					})
 						.addSource(
 							new ObjectSource({
-								port: "${PORT_1:PORT_2:PORT_3}",
-								host: "localhost:${PORT_1:PORT_2:PORT_3}",
+								port: "${PORT_1::PORT_2::PORT_3}",
+								host: "localhost:${PORT_1::PORT_2::PORT_3}",
 							}),
 						)
 						.build(),
@@ -210,8 +309,24 @@ describe.each(builders)(
 					})
 						.addSource(
 							new ObjectSource({
-								port: "${PORT_1:PORT_2:PORT_3:-3000}",
-								host: "localhost:${PORT_1:PORT_2:PORT_3:-3000}",
+								port: "${PORT::-3000}",
+								host: "localhost:${PORT::-3000}",
+							}),
+						)
+						.build(),
+				).toEqual({
+					port: 3000,
+					host: "localhost:3000",
+				});
+
+				expect(
+					new ConfigBuilder({
+						validate: (finalConfig) => schema.parse(finalConfig),
+					})
+						.addSource(
+							new ObjectSource({
+								port: "${PORT_1:PORT_2:PORT_3::-3000}",
+								host: "localhost:${PORT_1:PORT_2:PORT_3::-3000}",
 							}),
 						)
 						.build(),
@@ -221,69 +336,38 @@ describe.each(builders)(
 				});
 			});
 
-			it("should not replace value if env var is undefined and console.warn", () => {
-				const warnSpy = vi.spyOn(console, "warn");
-				const schema = z.object({
-					host: z.string(),
-				});
+			describe("Self-referencing slot", () => {
+				it("should replace the self-reference slot with the property value", () => {
+					const schema = z.object({
+						port: z.coerce.number().int().positive(),
+						host: z.string(),
+					});
 
-				expect(
-					new ConfigBuilder({
-						validate: (finalConfig) => schema.parse(finalConfig),
-					})
-						.addSource(
-							new ObjectSource({
-								host: "${PORT_1:PORT_2:PORT_3}",
-							}),
-						)
-						.build(),
-				).toEqual({
-					host: "${PORT_1:PORT_2:PORT_3}",
-				});
-
-				expect(warnSpy).toHaveBeenCalledWith(
-					"[MULTI_VARIABLE_SLOT]",
-					'None of the variables \"PORT_1, PORT_2, PORT_3\" are defined in the runtime environment. The slot will not be replaced.',
-				);
-			});
-		});
-
-		describe("Self-referencing slot", () => {
-			it("should replace the self-reference slot with the property value", () => {
-				const schema = z.object({
-					port: z.coerce.number().int().positive(),
-					host: z.string(),
-				});
-
-				expect(
-					new ConfigBuilder({
-						validate: (finalConfig) => schema.parse(finalConfig),
-						runtimeEnv: {
-							PORT: "3000",
-						},
-					})
-						.addSource(
-							new ObjectSource({
-								host: "localhost:${self.port}",
-								port: "$PORT",
-							}),
-						)
-						.build(),
-				).toEqual({
-					host: "localhost:3000",
-					port: 3000,
+					expect(
+						new ConfigBuilder({
+							validate: (finalConfig) => schema.parse(finalConfig),
+							runtimeEnv: {
+								PORT: "3000",
+							},
+						})
+							.addSource(
+								new ObjectSource({
+									host: "localhost:${self.port}",
+									port: "${PORT}",
+								}),
+							)
+							.build(),
+					).toEqual({
+						host: "localhost:3000",
+						port: 3000,
+					});
 				});
 			});
 
-			it("should not replace self-reference if value is not defined and console.warn", () => {
-				const warnSpy = vi.spyOn(console, "warn");
-				const schema = z.object({
-					host: z.string(),
-				});
-
+			it("should replace self-reference slot with undefined if it points to a non-existing property", () => {
 				expect(
 					new ConfigBuilder({
-						validate: (finalConfig) => schema.parse(finalConfig),
+						validate: (finalConfig) => finalConfig,
 						runtimeEnv: {},
 					})
 						.addSource(
@@ -293,13 +377,8 @@ describe.each(builders)(
 						)
 						.build(),
 				).toEqual({
-					host: "localhost:${self.port}",
+					host: undefined,
 				});
-
-				expect(warnSpy).toHaveBeenCalledWith(
-					"[SELF_REFERENCING_SLOT]",
-					'Self-referencing slot (path \"port\") is not defined in the config object. The slot will not be replaced.',
-				);
 			});
 
 			it("should throw error if path is not defined", () => {
@@ -428,7 +507,7 @@ describe.each(builders)(
 				});
 			});
 
-			it("should not replace anything if env var value is not defined", () => {
+			it("should replace value with undefined if env var is undefined", () => {
 				expect(
 					new ClientModule.ConfigBuilder({
 						validate: (finalConfig) => finalConfig,
@@ -438,13 +517,13 @@ describe.each(builders)(
 					})
 						.addSource(
 							new ObjectSource({
-								host: "$HOST",
+								host: "${HOST}",
 							}),
 						)
 						.addSource(new EnvironmentVariableSource())
 						.build(),
 				).toEqual({
-					host: "$HOST",
+					host: undefined,
 				});
 			});
 

--- a/packages/config/src/sources/source.ts
+++ b/packages/config/src/sources/source.ts
@@ -110,8 +110,16 @@ export abstract class Source<T = Record<string, unknown>> {
 		}
 
 		if (Array.isArray(value)) {
-			// TODO: FILTER UNDEFINED
-			return value.map((item) => this.#cleanUndefinedMarkers(item));
+			const newList: any[] = [];
+
+			for (const item of value) {
+				const cleanedItem = this.#cleanUndefinedMarkers(item);
+				if (cleanedItem !== undefined) {
+					newList.push(cleanedItem);
+				}
+			}
+
+			return newList;
 		}
 
 		if (value && typeof value === "object") {

--- a/packages/config/src/sources/source.ts
+++ b/packages/config/src/sources/source.ts
@@ -80,10 +80,6 @@ export abstract class Source<T = Record<string, unknown>> {
 	): Slot[] {
 		const result: Slot[] = [];
 
-		if (value === undefined || value === null) {
-			return result;
-		}
-
 		if (Array.isArray(value)) {
 			for (const item of value) {
 				result.push(...this.#extractSlots(item as UnknownRecord, slotPrefix));

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -57,6 +57,7 @@ export type RuntimeEnv = zm.output<typeof RuntimeEnv>;
 export const DEFAULT_SLOT_PREFIX = "$" as const;
 
 export type UnknownRecord = Record<string, unknown>;
+export type UnknownArray = Array<unknown>;
 
 interface BaseConfigBuilderOptions {
 	/**

--- a/packages/config/src/utils/slot.test.ts
+++ b/packages/config/src/utils/slot.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, test } from "vitest";
+import { DEFAULT_SLOT_PREFIX } from "../types";
+import { extractSlotsFromExpression, hasSlot } from "./slot";
+
+describe("fn: extractSlotsFromExpression", () => {
+	test.each([
+		{
+			match: "${PORT}",
+			fallbackValue: undefined,
+			references: [
+				{
+					type: "env_var",
+					envVar: "PORT",
+				},
+			],
+		},
+		{
+			match: "${PORT::-3000}",
+			fallbackValue: "3000",
+			references: [
+				{
+					type: "env_var",
+					envVar: "PORT",
+				},
+			],
+		},
+		{
+			match: "${self.hostname}",
+			fallbackValue: undefined,
+			references: [
+				{
+					type: "self_reference",
+					propertyPath: "hostname",
+				},
+			],
+		},
+		{
+			match: "${self.hostname::HOSTNAME}",
+			fallbackValue: undefined,
+			references: [
+				{
+					type: "self_reference",
+					propertyPath: "hostname",
+				},
+				{
+					type: "env_var",
+					envVar: "HOSTNAME",
+				},
+			],
+		},
+		{
+			match: "${HOSTNAME::self.hostname}",
+			fallbackValue: undefined,
+			references: [
+				{
+					type: "env_var",
+					envVar: "HOSTNAME",
+				},
+				{
+					type: "self_reference",
+					propertyPath: "hostname",
+				},
+			],
+		},
+		{
+			match: "${HOSTNAME::self.hostname::-localhost}",
+			fallbackValue: "localhost",
+			references: [
+				{
+					type: "env_var",
+					envVar: "HOSTNAME",
+				},
+				{
+					type: "self_reference",
+					propertyPath: "hostname",
+				},
+			],
+		},
+	])(
+		"Slot Match $match | Fallback $fallbackValue",
+		({ match, fallbackValue, references }) => {
+			const slots = extractSlotsFromExpression(match, DEFAULT_SLOT_PREFIX);
+			for (const slot of slots) {
+				expect(slot.slotMatch).toBe(match);
+				expect(slot.fallbackValue).toBe(fallbackValue);
+				expect(slot.references).toStrictEqual(references);
+			}
+		},
+	);
+});
+
+describe("fn: hasSlot", () => {
+	it("should return true if slot exists", () => {
+		const content = "This is a test with ${FOO} and ${BAR::self.baz}";
+		expect(hasSlot(content, DEFAULT_SLOT_PREFIX)).toBe(true);
+	});
+
+	it("should return false if slot does not exist", () => {
+		const content = "This is a test without slots";
+		expect(hasSlot(content, DEFAULT_SLOT_PREFIX)).toBe(false);
+	});
+});

--- a/packages/config/src/utils/slot.ts
+++ b/packages/config/src/utils/slot.ts
@@ -1,0 +1,101 @@
+interface EnvVarSlot {
+	type: "env_var";
+	envVar: string;
+}
+
+interface SelfReferenceSlot {
+	type: "self_reference";
+	propertyPath: string;
+}
+
+export function extractSlotsFromExpression(
+	content: string,
+	slotPrefix: string,
+): Slot[] {
+	const slots: Slot[] = [];
+	const regex = getTemplateRegex(slotPrefix);
+
+	let match: RegExpExecArray | null;
+
+	// biome-ignore lint/suspicious/noAssignInExpressions: easy brow, it's fine.
+	while ((match = regex.exec(content)) !== null) {
+		const [fullMatch, slotValue] = match;
+
+		if (!slotValue) {
+			throw new Error("Slot value is missing");
+		}
+
+		slots.push(new Slot(fullMatch, slotValue));
+	}
+
+	return slots;
+}
+
+export function hasSlot(content: string, slotPrefix: string): boolean {
+	const regex = getTemplateRegex(slotPrefix);
+	return regex.test(content);
+}
+
+export class Slot {
+	#references: (SelfReferenceSlot | EnvVarSlot)[] = [];
+	#slotMatch: string;
+	#slotContent: string;
+	#fallbackValue: string | undefined;
+	#separator = "::";
+
+	constructor(slotMatch: string, slotContent: string) {
+		this.#slotMatch = slotMatch;
+		this.#slotContent = slotContent;
+
+		const slotParts = this.#slotContent.split(this.#separator);
+
+		//Check for fallback (last value starting with -)
+		if (
+			slotParts.length > 1 &&
+			slotParts[slotParts.length - 1]?.startsWith("-")
+		) {
+			this.#fallbackValue = slotParts.pop()?.slice(1);
+		}
+
+		for (const slotPart of slotParts) {
+			if (slotPart.startsWith("self.")) {
+				const propertyPath = slotPart.trim().replace("self.", "").trim();
+
+				if (!propertyPath) {
+					throw new Error(
+						`Invalid self-referencing slot pattern: "\${self.}". Object Path is missing.`,
+					);
+				}
+
+				this.#references.push({
+					type: "self_reference",
+					propertyPath,
+				});
+			} else {
+				this.#references.push({
+					type: "env_var",
+					envVar: slotPart.trim(),
+				});
+			}
+		}
+	}
+
+	get fallbackValue(): string | undefined {
+		return this.#fallbackValue;
+	}
+
+	get slotMatch(): string {
+		return this.#slotMatch;
+	}
+
+	get references(): (SelfReferenceSlot | EnvVarSlot)[] {
+		return [...this.#references];
+	}
+}
+
+function getTemplateRegex(slotPrefix: string) {
+	// Escape special regex characters in the prefix
+	const escapedPrefix = slotPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	// Build the regex pattern
+	return new RegExp(`${escapedPrefix}\\{([^}]*)\\}`, "g");
+}


### PR DESCRIPTION
> Closes #146 

This pull request introduces a major refactor to the slot syntax in the `@layerfig/config` package, updates dependencies, and improves documentation and testing to reflect the new slot resolution logic. The most significant change is the breaking update to how slots are defined and resolved, simplifying the syntax and making slot evaluation more predictable, especially for fallback and multi-slot cases. The documentation and tests have been updated to match the new behavior.

**Slot syntax refactor and behavior changes:**

* **Breaking change:** All slots must now be wrapped in `${}` (e.g., `"${PORT}"` instead of `"$PORT"`), and the slot separator has changed from `:` to `::` (e.g., `"${APP_PORT::PORT}"`). Fallbacks are now specified with `::-` (e.g., `"${PORT::-3000}"`). This simplifies and standardizes slot definitions. (`.changeset/busy-rooms-sell.md`, `docs/src/content/docs/migrate-to-v3.mdx`, `docs/src/content/docs/setup/slots.mdx`, `docs/config/base.yaml`, [[1]](diffhunk://#diff-1db2b994564f2b101c90f4d4baaedabbb46954df59f9388b08a616bc18030c19R125-R157) [[2]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL30-R31) [[3]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL53-R57) [[4]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL81-R92) [[5]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL107-R107) [[6]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL118-R118) [[7]](diffhunk://#diff-2cfc6e9347950f25b4505c82bc4da777a419da9f3d55d45a302e95a8d8db0c57L1-R2)R1, [[8]](diffhunk://#diff-5ab0bc8c96ede5d4b5a74666360abf474c1eed1b079ec41d0a5fe06fb8b079ddR1-R59)
* **Slot resolution behavior:** If a slot cannot be resolved (e.g., missing env var or config property), it is now replaced with `undefined` instead of leaving the slot string in the result. For arrays, unresolved slots are removed from the array. (`docs/src/content/docs/setup/slots.mdx`, `packages/config/src/config-builder.test.ts`, [[1]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL128-R153) [[2]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L72-R222) [[3]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L296-L302)

**Testing improvements:**

* **Comprehensive test rewrite:** The configuration builder tests have been rewritten to cover the new slot syntax and behaviors, including complex slot chains, fallbacks, self-references, and handling of undefined slots. Old tests and warnings for unresolved slots have been removed in favor of the new `undefined` behavior. (`packages/config/src/config-builder.test.ts`, [[1]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L22-R185) [[2]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L72-R222) [[3]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L148-R248) [[4]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L169-R269) [[5]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L190-R290) [[6]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L213-R335) [[7]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L268-R356) [[8]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L277-R370) [[9]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5L296-L302)

**Documentation updates:**

* **Migration and setup docs:** The migration guide and slot documentation have been updated to explain the new slot syntax, separator, fallback handling, and the new behavior for unresolved slots. Examples throughout the docs have been updated for clarity and accuracy. (`docs/src/content/docs/migrate-to-v3.mdx`, `docs/src/content/docs/setup/slots.mdx`, [[1]](diffhunk://#diff-1db2b994564f2b101c90f4d4baaedabbb46954df59f9388b08a616bc18030c19R125-R157) [[2]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL30-R31) [[3]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL53-R57) [[4]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL81-R92) [[5]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL107-R107) [[6]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL118-R118) [[7]](diffhunk://#diff-88f45ce269052616da8eff63fd40bb5a3003ce8da856e69e94551f2d3dd2f99cL128-R153)

**Dependency and tooling updates:**

* **Dependency upgrades:** The `zod` dependency is updated from `4.0.10` to `4.0.17` and `@biomejs/biome` from `2.1.2` to `2.1.4` for improved validation and linting. (`packages/config/package.json`, `package.json`, [[1]](diffhunk://#diff-fd956f6d78d80e1989716c00afb66f1ac64847e9b4a3673def6f483cd218e963L82-R82) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R22) [[3]](diffhunk://#diff-c8bbc21622dc758d93882e94976c396a68fdcebddd7904c335569e1af8e4bd44R1-R5)
* **Tooling enhancements:** Added a VSCode launch configuration for debugging tests with Bun, and set the project type to `module` in `package.json`. (`.vscode/launch.json`, `package.json`, [[1]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R19) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5)

These changes collectively modernize the configuration experience, improve reliability, and streamline both usage and maintenance of the `@layerfig/config` package.