### PR TITLE
Refactor zod imports to use official packages instead of local re-exports

### DIFF
--- a/.changeset/thin-states-doubt.md
+++ b/.changeset/thin-states-doubt.md
@@ -1,0 +1,9 @@
+---
+"@layerfig/config": patch
+---
+
+Refactor zod imports to use the official `zod` and `zod/mini` packages instead of local re-exports.
+
+This will fix types not being resolved properly.
+
+

--- a/packages/config/src/client/index.ts
+++ b/packages/config/src/client/index.ts
@@ -1,5 +1,5 @@
+export { z } from "zod/mini";
 export * from "../sources/env-var";
 export * from "../sources/object";
-export { z } from "../zod-mini";
 export * from "./config-builder";
 export type { ConfigBuilderOptions } from "./types";

--- a/packages/config/src/client/types.ts
+++ b/packages/config/src/client/types.ts
@@ -1,3 +1,4 @@
+import { z } from "zod/mini";
 import { EnvironmentVariableSource } from "../sources/env-var";
 import { ObjectSource } from "../sources/object";
 import {
@@ -7,7 +8,6 @@ import {
 	type UnknownRecord,
 	type ValidatedClientConfigBuilderOptions,
 } from "../types";
-import { z } from "../zod-mini";
 
 /**
  * This notation only serves to not have the following error:

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import { assertType, describe, expect, it } from "vitest";
+import { z } from "zod";
 import * as ClientModule from "./client";
 import { basicJsonParser } from "./parser/parser-json";
 import * as ServerModule from "./server";
 import { FileSource } from "./server";
 import { EnvironmentVariableSource } from "./sources/env-var";
 import { ObjectSource } from "./sources/object";
-import { z } from "./zod";
 
 const builders = [
 	{ ConfigBuilder: ClientModule.ConfigBuilder, mode: "Client" },

--- a/packages/config/src/server/index.ts
+++ b/packages/config/src/server/index.ts
@@ -1,7 +1,7 @@
+export { z } from "zod";
 export * from "../parser/config-parser";
 export * from "../sources/env-var";
 export * from "../sources/object";
-export { z } from "../zod";
 export * from "./config-builder";
 export * from "./file-source";
 export type { ConfigBuilderOptions } from "./types";

--- a/packages/config/src/server/types.ts
+++ b/packages/config/src/server/types.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { z } from "zod/mini";
 import type { ConfigParser } from "../parser/config-parser";
 import { basicJsonParser } from "../parser/parser-json";
 import {
@@ -8,7 +9,6 @@ import {
 	type UnknownRecord,
 	type ValidatedServerConfigBuilderOptions,
 } from "../types";
-import { z } from "../zod-mini";
 
 export const ServerConfigBuilderOptionsSchema: z.ZodMiniType<ValidatedServerConfigBuilderOptions> =
 	z.object({

--- a/packages/config/src/sources/env-var.ts
+++ b/packages/config/src/sources/env-var.ts
@@ -1,6 +1,6 @@
 import { set } from "es-toolkit/compat";
+import { z } from "zod/mini";
 import type { LoadSourceOptions } from "../types";
-import { z } from "../zod-mini";
 import { Source } from "./source";
 
 export class EnvironmentVariableSource extends Source {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,6 +1,6 @@
+import type { z as zod } from "zod";
+import { z as zm } from "zod/mini";
 import type { ConfigParser } from "./parser/config-parser";
-import type { z as zod } from "./zod";
-import { z as zm } from "./zod-mini";
 
 interface ResultSuccess<TSuccess = undefined> {
 	ok: true;

--- a/packages/config/src/utils/read-if-exist.ts
+++ b/packages/config/src/utils/read-if-exist.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
+import { z } from "zod/mini";
 import type { Result } from "../types";
-import { z } from "../zod-mini";
 
 export function readIfExist(filePath: string): Result<string, string> {
 	if (fs.existsSync(filePath)) {


### PR DESCRIPTION
This pull request refactors how the `zod` schema validation library is imported and used throughout the `@layerfig/config` package. Instead of relying on local re-exports, the code now directly imports from the official `zod` and `zod/mini` packages. This change resolves issues with type resolution and makes the imports clearer and more maintainable.

**Refactoring zod imports:**
- All imports of `z` and `zm` have been updated to use the official `zod` and `zod/mini` packages directly, replacing previous imports from local files such as `./zod` and `./zod-mini` throughout the codebase. [[1]](diffhunk://#diff-d919f1dab8577e295f81b487745d477074f4b1b363989a72ac05f20d64bd5f98R1-L3) [[2]](diffhunk://#diff-3a052d3a2e169adc04f664dc94c51a282b3d79d70e9debce2e31d9d1e7018207R1-L4) [[3]](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5R3-L9) [[4]](diffhunk://#diff-15d94b3236799f1500dd46bb2a902ba25292e3a4c6dba4777ea74aa6f041b216R1) [[5]](diffhunk://#diff-15d94b3236799f1500dd46bb2a902ba25292e3a4c6dba4777ea74aa6f041b216L10) [[6]](diffhunk://#diff-a8490766ea79c5ead990d3d92efba11f2b49d9843e22297f012c8bb85abde210R2) [[7]](diffhunk://#diff-a8490766ea79c5ead990d3d92efba11f2b49d9843e22297f012c8bb85abde210L11) [[8]](diffhunk://#diff-c42b8f7d4d9256e492ae3aaedf4322b7a53ef9dc88b03870c8c1504abaf2f823R2-L3) [[9]](diffhunk://#diff-bc8790029ada0b92644abb2c63a2cfeac3a0854eb92e1e66cd8bb6c9e9428189R1-L3) [[10]](diffhunk://#diff-f0512757ae22dd4e1ad64b05b685b69403a99b2504f167aac75a8e394730a5a9R2-L3) [[11]](diffhunk://#diff-8de6c7fec6027d233e4c5e52f8ec262e5fb13450b8d6eacf3dfef769085840caR1-R9)

**Improved type resolution:**
- This refactor addresses issues with types not being resolved properly by ensuring all type imports reference the official `zod` packages.