### PR TITLE
Add escapeBreakLine utility and tests for special character handling

### DIFF
--- a/.changeset/tasty-baboons-run.md
+++ b/.changeset/tasty-baboons-run.md
@@ -1,0 +1,7 @@
+---
+"@layerfig/config": patch
+---
+
+Fix: escape line breaks and special characters in slot values
+
+- Safely escape \, ", \n, \r, and \t before insertion to avoid misparse/misrender issues.

--- a/packages/config/src/config-builder.test.ts
+++ b/packages/config/src/config-builder.test.ts
@@ -199,6 +199,31 @@ describe.each(builders)(
 		});
 
 		describe("slots", () => {
+			it("should handle multiline values", () => {
+				const pemKeyMock = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEINofexMSQApYFYPK1/oISaOG4BgHm9SEkiHRUQOcmloToAoGCCqGSM49
+AwEHoUQDQgAEoRFl5IWEgK9PTCvI8lzT1kBdvFvVw/EZzKT8XHQczrBnVSc+S8qw
+tQrWvRJknz7jP0GHpvUm2GXHx6aOcbdBag==
+-----END EC PRIVATE KEY-----`;
+
+				const config = new ConfigBuilder({
+					validate: (finalConfig) => finalConfig,
+					runtimeEnv: {
+						PEM_KEY: pemKeyMock,
+					},
+				})
+					.addSource(
+						new ObjectSource({
+							multiline: "${PEM_KEY}",
+						}),
+					)
+					.build();
+
+				expect(config).toEqual({
+					multiline: pemKeyMock,
+				});
+			});
+
 			it("should replace single slots", () => {
 				const schema = z.object({
 					port: z.coerce.number().int().positive(),

--- a/packages/config/src/sources/source.ts
+++ b/packages/config/src/sources/source.ts
@@ -35,7 +35,11 @@ export abstract class Source<T = Record<string, unknown>> {
 			options.slotPrefix,
 		);
 
-		let updatedContentString = options.contentString;
+		/**
+		 * At this moment it does not matter what parser the user had defined,
+		 * we're in the JS/JSON land.
+		 */
+		let updatedContentString = JSON.stringify(initialObject);
 
 		for (const slot of slots) {
 			let envVarValue: RuntimeEnvValue;

--- a/packages/config/src/sources/source.ts
+++ b/packages/config/src/sources/source.ts
@@ -7,6 +7,7 @@ import type {
 	UnknownArray,
 	UnknownRecord,
 } from "../types";
+import { escapeBreakLine } from "../utils/escape-break-line";
 import { extractSlotsFromExpression, hasSlot, type Slot } from "../utils/slot";
 
 const UNDEFINED_MARKER = "___UNDEFINED_MARKER___" as const;
@@ -45,7 +46,7 @@ export abstract class Source<T = Record<string, unknown>> {
 				}
 
 				if (reference.type === "self_reference") {
-					const partialObj = options.transform(updatedContentString);
+					const partialObj = JSON.parse(updatedContentString);
 
 					envVarValue = get(
 						partialObj,
@@ -63,16 +64,19 @@ export abstract class Source<T = Record<string, unknown>> {
 				envVarValue = slot.fallbackValue;
 			}
 
-			updatedContentString = updatedContentString.replaceAll(
-				slot.slotMatch,
+			const valueToInsert =
 				envVarValue !== null && envVarValue !== undefined
 					? String(envVarValue)
-					: UNDEFINED_MARKER,
+					: UNDEFINED_MARKER;
+
+			updatedContentString = updatedContentString.replaceAll(
+				slot.slotMatch,
+				escapeBreakLine(valueToInsert),
 			);
 		}
 
 		const partialConfig = this.#cleanUndefinedMarkers(
-			options.transform(updatedContentString),
+			JSON.parse(updatedContentString),
 		);
 
 		return partialConfig;

--- a/packages/config/src/utils/escape-break-line.test.ts
+++ b/packages/config/src/utils/escape-break-line.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { escapeBreakLine } from "./escape-break-line";
+
+describe("escapeBreakLine", () => {
+	it("should escape newlines", () => {
+		const input = "line1\nline2\nline3";
+		const expected = "line1\\nline2\\nline3";
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should escape double quotes", () => {
+		const input = 'He said "Hello World"';
+		const expected = 'He said \\"Hello World\\"';
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should escape backslashes", () => {
+		const input = "path\\to\\file";
+		const expected = "path\\\\to\\\\file";
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should escape carriage returns", () => {
+		const input = "line1\rline2";
+		const expected = "line1\\rline2";
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should escape tabs", () => {
+		const input = "col1\tcol2\tcol3";
+		const expected = "col1\\tcol2\\tcol3";
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should handle empty string", () => {
+		expect(escapeBreakLine("")).toBe("");
+	});
+
+	it("should handle string with no special characters", () => {
+		const input = "simple string";
+		expect(escapeBreakLine(input)).toBe(input);
+	});
+
+	it("should escape multiple special characters in correct order", () => {
+		const input = 'test\\with"quotes\nand\ttabs';
+		const expected = 'test\\\\with\\"quotes\\nand\\ttabs';
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+
+	it("should handle PEM key format", () => {
+		const pemKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEINofexMSQApYFYPK1/oISaOG4BgHm9SEkiHRUQOcmloToAoGCCqGSM49
+AwEHoUQDQgAEoRFl5IWEgK9PTCvI8lzT1kBdvFvVw/EZzKT8XHQczrBnVSc+S8qw
+tQrWvRJknz7jP0GHpvUm2GXHx6aOcbdBag==
+-----END EC PRIVATE KEY-----`;
+
+		const escaped = escapeBreakLine(pemKey);
+
+		// Should not contain actual newlines
+		expect(escaped).not.toContain("\n");
+		// Should contain escaped newlines
+		expect(escaped).toContain("\\n");
+		// Should start and end correctly
+		expect(escaped).toMatch(/^-----BEGIN EC PRIVATE KEY-----\\n/);
+		expect(escaped).toMatch(/\\n-----END EC PRIVATE KEY-----$/);
+	});
+
+	it("should handle complex strings with all escape characters", () => {
+		const input = 'backslash: \\ quote: " newline: \n tab: \t carriage: \r';
+		const expected =
+			'backslash: \\\\ quote: \\" newline: \\n tab: \\t carriage: \\r';
+		expect(escapeBreakLine(input)).toBe(expected);
+	});
+});

--- a/packages/config/src/utils/escape-break-line.ts
+++ b/packages/config/src/utils/escape-break-line.ts
@@ -1,0 +1,12 @@
+export function escapeBreakLine<T = unknown>(value: T): T {
+	if (typeof value !== "string") {
+		return value;
+	}
+
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, "\\n")
+		.replace(/\r/g, "\\r")
+		.replace(/\t/g, "\\t") as T;
+}


### PR DESCRIPTION
> Closes #162 

This pull request improves the handling of slot values in the `@layerfig/config` package, especially for multiline and special-character-containing strings. The main change is the introduction of a utility to safely escape line breaks and special characters before slot value insertion, preventing misparsing and rendering issues. Additionally, tests have been added to ensure correct escaping, and the slot replacement logic in sources has been updated accordingly.

**Escaping and slot value handling:**
- Added a new utility function `escapeBreakLine` to escape backslashes, double quotes, newlines, carriage returns, and tabs in slot values before insertion, preventing parsing and rendering errors. (`packages/config/src/utils/escape-break-line.ts`, [packages/config/src/utils/escape-break-line.tsR1-R12](diffhunk://#diff-bb6546fe24600397aaa3d915bcc6e218f0e9060d70ad3472989f7c78d766f64dR1-R12))
- Updated slot replacement logic in `Source` to use `escapeBreakLine` when inserting slot values, and refactored parsing to use `JSON.parse` directly for consistency. (`packages/config/src/sources/source.ts`, [[1]](diffhunk://#diff-f7bd6bcbbd41789c51b49c8163405fcb67ff3374eabb2b18d3d704710e5898f0R10) [[2]](diffhunk://#diff-f7bd6bcbbd41789c51b49c8163405fcb67ff3374eabb2b18d3d704710e5898f0L48-R49) [[3]](diffhunk://#diff-f7bd6bcbbd41789c51b49c8163405fcb67ff3374eabb2b18d3d704710e5898f0L66-R79)

**Testing improvements:**
- Added comprehensive unit tests for `escapeBreakLine`, covering all relevant escape scenarios including multiline PEM keys and combinations of special characters. (`packages/config/src/utils/escape-break-line.test.ts`, [packages/config/src/utils/escape-break-line.test.tsR1-R74](diffhunk://#diff-214f44f118b4839c6f3eb4514ff9935cc04eeb444ee7cfebac5104f4eefef984R1-R74))
- Added a test to ensure that multiline slot values (such as PEM keys) are correctly handled and preserved in the final configuration. (`packages/config/src/config-builder.test.ts`, [packages/config/src/config-builder.test.tsR202-R226](diffhunk://#diff-11ce8aee3af998f44ac1cb0182be0d18d66661e74d5e3cc14ee788eb2a0e21e5R202-R226))

**Documentation and changelog:**
- Added a changeset documenting the fix for escaping line breaks and special characters in slot values. (`.changeset/tasty-baboons-run.md`, [.changeset/tasty-baboons-run.mdR1-R7](diffhunk://#diff-b259537e5e49b241ce58cff37f52557560873531e17b3d038bffe5e1a79f6ea3R1-R7))